### PR TITLE
Adding initial support for decisions, content, and actions.

### DIFF
--- a/config/install/core.entity_form_display.eloqua_app_cloud_service.decision.default.yml
+++ b/config/install/core.entity_form_display.eloqua_app_cloud_service.decision.default.yml
@@ -1,0 +1,33 @@
+status: true
+dependencies:
+  config:
+    - eloqua_app_cloud.eloqua_app_cloud_service_type.decision
+    - field.field.eloqua_app_cloud_service.decision.field_eloqua_app_cloud_responder
+  module:
+    - pluginreference
+id: eloqua_app_cloud_service.decision.default
+targetEntityType: eloqua_app_cloud_service
+bundle: decision
+mode: default
+content:
+  field_eloqua_app_cloud_responder:
+    weight: 6
+    settings: {  }
+    third_party_settings: {  }
+    type: plugin_reference_select
+  name:
+    type: string_textfield
+    weight: -4
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  user_id:
+    type: entity_reference_autocomplete
+    weight: 5
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/config/install/core.entity_view_display.eloqua_app_cloud_service.decision.default.yml
+++ b/config/install/core.entity_view_display.eloqua_app_cloud_service.decision.default.yml
@@ -1,0 +1,21 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - eloqua_app_cloud.eloqua_app_cloud_service_type.decision
+    - field.field.eloqua_app_cloud_service.decision.field_eloqua_app_cloud_responder
+id: eloqua_app_cloud_service.decision.default
+targetEntityType: eloqua_app_cloud_service
+bundle: decision
+mode: default
+content:
+  name:
+    label: visually_hidden
+    type: string
+    weight: -4
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+hidden:
+  field_eloqua_app_cloud_responder: true
+  user_id: true

--- a/config/install/eloqua_app_cloud.eloqua_app_cloud_service_type.decision.yml
+++ b/config/install/eloqua_app_cloud.eloqua_app_cloud_service_type.decision.yml
@@ -1,0 +1,4 @@
+id: menu
+label: 'Decision Service'
+status: true
+dependencies: {  }

--- a/config/install/eloqua_app_cloud.eloqua_app_cloud_service_type.decision.yml
+++ b/config/install/eloqua_app_cloud.eloqua_app_cloud_service_type.decision.yml
@@ -1,4 +1,4 @@
-id: menu
+id: decision_service
 label: 'Decision Service'
 status: true
 dependencies: {  }

--- a/eloqua_app_cloud.module
+++ b/eloqua_app_cloud.module
@@ -38,6 +38,11 @@ function eloqua_app_cloud_theme() {
     'variables' => ['content' => NULL],
     'file' => 'eloqua_app_cloud_service.page.inc',
   ];
+  $theme['eloqua_app_cloud_update'] = array(
+    'variables' => ['content' => NULL],
+    'file' => 'EloquaAppCloudEndpointController.php',
+    'template' => 'eloqua_app_cloud_update',
+  );
   return $theme;
 }
 

--- a/eloqua_app_cloud.module
+++ b/eloqua_app_cloud.module
@@ -38,9 +38,9 @@ function eloqua_app_cloud_theme() {
     'variables' => ['content' => NULL],
     'file' => 'eloqua_app_cloud_service.page.inc',
   ];
-  $theme['eloqua_app_cloud_update'] = array(
+  $theme['eloqua_app_cloud_update_dialog'] = array(
     'variables' => ['content' => NULL],
-    'template' => 'eloqua_app_cloud_update',
+    'template' => 'eloqua_app_cloud_update_dialog',
   );
   return $theme;
 }

--- a/eloqua_app_cloud.module
+++ b/eloqua_app_cloud.module
@@ -40,7 +40,6 @@ function eloqua_app_cloud_theme() {
   ];
   $theme['eloqua_app_cloud_update'] = array(
     'variables' => ['content' => NULL],
-    'file' => 'EloquaAppCloudEndpointController.php',
     'template' => 'eloqua_app_cloud_update',
   );
   return $theme;

--- a/eloqua_app_cloud.routing.yml
+++ b/eloqua_app_cloud.routing.yml
@@ -15,7 +15,7 @@ eloqua_app_cloud.endpoint_controller_instantiate:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::instantiate'
     _title: 'Instantiate'
   requirements:
-    _permission: 'access content'
+    _eloqua_oauth_validate: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_update:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/update'
@@ -23,7 +23,7 @@ eloqua_app_cloud.endpoint_controller_update:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::update'
     _title: 'Update'
   requirements:
-    _permission: 'access content'
+    _eloqua_oauth_validate: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_delete:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/delete'
@@ -31,7 +31,7 @@ eloqua_app_cloud.endpoint_controller_delete:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::delete'
     _title: 'Delete'
   requirements:
-    _permission: 'access content'
+    _eloqua_oauth_validate: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_execute:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/execute'
@@ -39,4 +39,4 @@ eloqua_app_cloud.endpoint_controller_execute:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::execute'
     _title: 'Execute'
   requirements:
-    _permission: 'access content'
+    _eloqua_oauth_validate: 'TRUE'

--- a/eloqua_app_cloud.routing.yml
+++ b/eloqua_app_cloud.routing.yml
@@ -8,3 +8,35 @@ eloqua_app_cloud.eloqua_app_cloud_admin_form:
     _permission: 'administer eloqua app cloud connector'
   options:
     _admin_route: TRUE
+
+eloqua_app_cloud.endpoint_controller_instantiate:
+  path: '/eloqua/hook/{eloqua_app_cloud_service}/instantiate'
+  defaults:
+    _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::instantiate'
+    _title: 'Instantiate'
+  requirements:
+    _permission: 'access content'
+
+eloqua_app_cloud.endpoint_controller_update:
+  path: '/eloqua/hook/{eloqua_app_cloud_service}/update'
+  defaults:
+    _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::update'
+    _title: 'Update'
+  requirements:
+    _permission: 'access content'
+
+eloqua_app_cloud.endpoint_controller_delete:
+  path: '/eloqua/hook/{eloqua_app_cloud_service}/delete'
+  defaults:
+    _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::delete'
+    _title: 'Delete'
+  requirements:
+    _permission: 'access content'
+
+eloqua_app_cloud.endpoint_controller_execute:
+  path: '/eloqua/hook/{eloqua_app_cloud_service}/execute'
+  defaults:
+    _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::execute'
+    _title: 'Execute'
+  requirements:
+    _permission: 'access content'

--- a/eloqua_app_cloud.routing.yml
+++ b/eloqua_app_cloud.routing.yml
@@ -10,14 +10,14 @@ eloqua_app_cloud.eloqua_app_cloud_admin_form:
     _admin_route: TRUE
 
 eloqua_app_cloud.endpoint_controller_instantiate:
-  path: '/eloqua/hook/{eloqua_app_cloud_service}/instantiate'
+  path: '/eloqua/hook/{eloquaAppCloudService}/instantiate'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::instantiate'
   requirements:
     _eloqua_oauth_validate: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_update:
-  path: '/eloqua/hook/{eloqua_app_cloud_service}/update'
+  path: '/eloqua/hook/{eloquaAppCloudService}/update'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::update'
     _title_callback: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::getTitle'
@@ -27,7 +27,7 @@ eloqua_app_cloud.endpoint_controller_update:
     no_cache: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_delete:
-  path: '/eloqua/hook/{eloqua_app_cloud_service}/delete'
+  path: '/eloqua/hook/{eloquaAppCloudService}/delete'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::delete'
     _title: ''
@@ -35,7 +35,7 @@ eloqua_app_cloud.endpoint_controller_delete:
     _eloqua_oauth_validate: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_execute:
-  path: '/eloqua/hook/{eloqua_app_cloud_service}/execute'
+  path: '/eloqua/hook/{eloquaAppCloudService}/execute'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::execute'
     _title: ''

--- a/eloqua_app_cloud.routing.yml
+++ b/eloqua_app_cloud.routing.yml
@@ -23,6 +23,8 @@ eloqua_app_cloud.endpoint_controller_update:
     _title_callback: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::getTitle'
   requirements:
     _eloqua_oauth_validate: 'TRUE'
+  options:
+    no_cache: 'TRUE'
 
 eloqua_app_cloud.endpoint_controller_delete:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/delete'

--- a/eloqua_app_cloud.routing.yml
+++ b/eloqua_app_cloud.routing.yml
@@ -13,7 +13,6 @@ eloqua_app_cloud.endpoint_controller_instantiate:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/instantiate'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::instantiate'
-    _title: 'Instantiate'
   requirements:
     _eloqua_oauth_validate: 'TRUE'
 
@@ -21,7 +20,7 @@ eloqua_app_cloud.endpoint_controller_update:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/update'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::update'
-    _title: 'Update'
+    _title_callback: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::getTitle'
   requirements:
     _eloqua_oauth_validate: 'TRUE'
 
@@ -29,7 +28,7 @@ eloqua_app_cloud.endpoint_controller_delete:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/delete'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::delete'
-    _title: 'Delete'
+    _title: ''
   requirements:
     _eloqua_oauth_validate: 'TRUE'
 
@@ -37,6 +36,6 @@ eloqua_app_cloud.endpoint_controller_execute:
   path: '/eloqua/hook/{eloqua_app_cloud_service}/execute'
   defaults:
     _controller: '\Drupal\eloqua_app_cloud\Controller\EloquaAppCloudEndpointController::execute'
-    _title: 'Execute'
+    _title: ''
   requirements:
     _eloqua_oauth_validate: 'TRUE'

--- a/eloqua_app_cloud.services.yml
+++ b/eloqua_app_cloud.services.yml
@@ -3,11 +3,14 @@ services:
     parent: logger.channel_base
     arguments: ['eloqua_app_cloud']
 
-  plugin.manager.eloqua_app_cloud_menu_responder.processor:
+  plugin.manager.eloqua_app_cloud.decision_responder.processor:
+    class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
+    parent: default_plugin_manager
+  plugin.manager.eloqua_app_cloud.menu_responder.processor:
     class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudMenuResponderManager
     parent: default_plugin_manager
 
-  plugin.manager.eloqua_app_cloud_firehose_responder.processor:
+  plugin.manager.eloqua_app_cloud.firehose_responder.processor:
     class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudFirehoseResponderManager
     parent: default_plugin_manager
 

--- a/eloqua_app_cloud.services.yml
+++ b/eloqua_app_cloud.services.yml
@@ -11,6 +11,10 @@ services:
       class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderManager
       parent: default_plugin_manager
 
+  plugin.manager.eloqua_app_cloud.content_responder.processor:
+      class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderManager
+      parent: default_plugin_manager
+      
   plugin.manager.eloqua_app_cloud.menu_responder.processor:
     class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudMenuResponderManager
     parent: default_plugin_manager

--- a/eloqua_app_cloud.services.yml
+++ b/eloqua_app_cloud.services.yml
@@ -6,6 +6,11 @@ services:
   plugin.manager.eloqua_app_cloud.decision_responder.processor:
     class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
     parent: default_plugin_manager
+
+  plugin.manager.eloqua_app_cloud.action_responder.processor:
+      class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderManager
+      parent: default_plugin_manager
+
   plugin.manager.eloqua_app_cloud.menu_responder.processor:
     class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudMenuResponderManager
     parent: default_plugin_manager

--- a/eloqua_app_cloud.services.yml
+++ b/eloqua_app_cloud.services.yml
@@ -2,6 +2,9 @@ services:
   logger.channel.eloqua_app_cloud:
     parent: logger.channel_base
     arguments: ['eloqua_app_cloud']
+  logger.channel.eloqua_app_cloud_queue:
+    parent: logger.channel_base
+    arguments: ['eloqua_app_cloud_queue']
 
   plugin.manager.eloqua_app_cloud.decision_responder.processor:
     class: Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager

--- a/src/Annotation/EloquaAppCloudActionResponder.php
+++ b/src/Annotation/EloquaAppCloudActionResponder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Eloqua AppCloud Decision Responder item annotation object.
+ *
+ * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class EloquaAppCloudActionResponder extends Plugin {
+
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * The list of fields required by the plugin.
+   *
+   * @var array
+   *
+   */
+  public $fieldList;
+
+  /**
+   * The API type (contacts or customObject).
+   * @var string
+   */
+  public $api;
+
+
+  /**
+   * The name of the queue worker this plugin requires.
+   * @var string
+   */
+  public $queueWorker;
+
+}

--- a/src/Annotation/EloquaAppCloudActionResponder.php
+++ b/src/Annotation/EloquaAppCloudActionResponder.php
@@ -5,51 +5,13 @@ namespace Drupal\eloqua_app_cloud\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
- * Defines a Eloqua AppCloud Decision Responder item annotation object.
+ * Defines a Eloqua AppCloud Action Responder item annotation object.
  *
- * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
+ * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderManager
  * @see plugin_api
  *
  * @Annotation
  */
-class EloquaAppCloudActionResponder extends Plugin {
-
-
-  /**
-   * The plugin ID.
-   *
-   * @var string
-   */
-  public $id;
-
-  /**
-   * The label of the plugin.
-   *
-   * @var \Drupal\Core\Annotation\Translation
-   *
-   * @ingroup plugin_translatable
-   */
-  public $label;
-
-  /**
-   * The list of fields required by the plugin.
-   *
-   * @var array
-   *
-   */
-  public $fieldList;
-
-  /**
-   * The API type (contacts or customObject).
-   * @var string
-   */
-  public $api;
-
-
-  /**
-   * The name of the queue worker this plugin requires.
-   * @var string
-   */
-  public $queueWorker;
+class EloquaAppCloudActionResponder extends EloquaAppCloudInteractiveResponder {
 
 }

--- a/src/Annotation/EloquaAppCloudContentResponder.php
+++ b/src/Annotation/EloquaAppCloudContentResponder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Eloqua AppCloud Content Responder item annotation object.
+ *
+ * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class EloquaAppCloudContentResponder extends Plugin {
+
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * The list of fields required by the plugin.
+   *
+   * @var array
+   *
+   */
+  public $fieldList;
+
+  /**
+   * The API type (contacts or customObject).
+   * @var string
+   */
+  public $api;
+
+
+  /**
+   * The name of the queue worker this plugin requires.
+   * @var string
+   */
+  public $queueWorker;
+
+}

--- a/src/Annotation/EloquaAppCloudContentResponder.php
+++ b/src/Annotation/EloquaAppCloudContentResponder.php
@@ -12,44 +12,6 @@ use Drupal\Component\Annotation\Plugin;
  *
  * @Annotation
  */
-class EloquaAppCloudContentResponder extends Plugin {
-
-
-  /**
-   * The plugin ID.
-   *
-   * @var string
-   */
-  public $id;
-
-  /**
-   * The label of the plugin.
-   *
-   * @var \Drupal\Core\Annotation\Translation
-   *
-   * @ingroup plugin_translatable
-   */
-  public $label;
-
-  /**
-   * The list of fields required by the plugin.
-   *
-   * @var array
-   *
-   */
-  public $fieldList;
-
-  /**
-   * The API type (contacts or customObject).
-   * @var string
-   */
-  public $api;
-
-
-  /**
-   * The name of the queue worker this plugin requires.
-   * @var string
-   */
-  public $queueWorker;
+class EloquaAppCloudContentResponder extends EloquaAppCloudInteractiveResponder {
 
 }

--- a/src/Annotation/EloquaAppCloudDecisionResponder.php
+++ b/src/Annotation/EloquaAppCloudDecisionResponder.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Eloqua AppCloud Decision Responder item annotation object.
+ *
+ * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class EloquaAppCloudDecisionResponder extends Plugin {
+
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * The list of fields required by the plugin.
+   *
+   * @var array
+   *
+   */
+  public $fieldList;
+
+  /**
+   * The API type (contacts or customObject).
+   * @var string
+   */
+  public $api;
+
+
+  /**
+   * The name of the queue worker this plugin requires.
+   * @var string
+   */
+  public $queueWorker;
+
+}

--- a/src/Annotation/EloquaAppCloudDecisionResponder.php
+++ b/src/Annotation/EloquaAppCloudDecisionResponder.php
@@ -12,44 +12,6 @@ use Drupal\Component\Annotation\Plugin;
  *
  * @Annotation
  */
-class EloquaAppCloudDecisionResponder extends Plugin {
-
-
-  /**
-   * The plugin ID.
-   *
-   * @var string
-   */
-  public $id;
-
-  /**
-   * The label of the plugin.
-   *
-   * @var \Drupal\Core\Annotation\Translation
-   *
-   * @ingroup plugin_translatable
-   */
-  public $label;
-
-  /**
-   * The list of fields required by the plugin.
-   *
-   * @var array
-   *
-   */
-  public $fieldList;
-
-  /**
-   * The API type (contacts or customObject).
-   * @var string
-   */
-  public $api;
-
-
-  /**
-   * The name of the queue worker this plugin requires.
-   * @var string
-   */
-  public $queueWorker;
+class EloquaAppCloudDecisionResponder extends EloquaAppCloudInteractiveResponder {
 
 }

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -14,7 +14,6 @@ use Drupal\Component\Annotation\Plugin;
  */
 class EloquaAppCloudInteractiveResponder extends Plugin {
 
-
   /**
    * The plugin ID.
    *

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -57,14 +57,6 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
    */
   public $api;
 
-
-  /**
-   * The name of the queue worker this plugin requires.
-   *
-   * @var string
-   */
-  public $queueWorker;
-
   /**
    * The tye of response this plugin expects (either synchronous or asynchronous).
    *

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -5,9 +5,10 @@ namespace Drupal\eloqua_app_cloud\Annotation;
 use Drupal\Component\Annotation\Plugin;
 
 /**
- * Defines a Eloqua AppCloud Decision Responder item annotation object.
+ * Defines a Eloqua AppCloud Interactive Responder
+ * as a base for other plugin types.
  *
- * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
+ * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudInteractiveResponderBase
  * @see plugin_api
  *
  * @Annotation

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -34,6 +34,17 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
   /**
    * The list of fields required by the plugin.
    *
+   * These must be presented in the form:
+   * fieldList = {
+   *   "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
+   *  },
+   *
+   * The key (i.e. EmailAddress), is arbitrary, but must be used consistently and is case sensitive.
+   * The value (i.e. Contact.Field(C_EmailAddress)), is the internal Eloqua field description.
+   * Extracting this value from Eloqua
+   * (possibly by using a call to https://secure.p01.eloqua.com/API/bulk/2.0/contacts/fields )
+   * is left as an exercise for the reader.
+   *
    * @var array
    *
    */
@@ -41,6 +52,7 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
 
   /**
    * The API type (contacts or customObject).
+   *
    * @var string
    */
   public $api;
@@ -48,12 +60,13 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
 
   /**
    * The name of the queue worker this plugin requires.
+   *
    * @var string
    */
   public $queueWorker;
 
   /**
-   * The tye of response this piugin expects (either synchronous or asynchronous.
+   * The tye of response this plugin expects (either synchronous or asynchronous).
    *
    * @var string
    */
@@ -61,12 +74,15 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
 
   /**
    * The description of this plugin. It will be returned to Eloqua on update requests.
+   *
    * @var string
    */
   public $description;
 
   /**
-   * Really a boolean flag but defined as a string since Eloqua seems to need lowercase "true" and "false".
+   * Really a boolean flag but defined as a string since Eloqua seems to need
+   * lowercase "true" and "false".
+   *
    * @var string
    */
   public $requiresConfiguration;

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -65,4 +65,10 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
    */
   public $description;
 
+  /**
+   * Really a boolean flag but defined as a string since Eloqua seems to need lowercase "true" and "false".
+   * @var string
+   */
+  public $requiresConfiguration;
+
 }

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -80,10 +80,12 @@ class EloquaAppCloudInteractiveResponder extends Plugin {
   public $description;
 
   /**
-   * Really a boolean flag but defined as a string since Eloqua seems to need
-   * lowercase "true" and "false".
+   * If true than Eloqua will require a call to the update endpoint, and the response must indicate
+   * requiresConfiguration = FALSE before a canvas can be activated.
    *
-   * @var string
+   * @TDDO: Implement the logic to make this work.
+   *
+   * @var boolean
    */
   public $requiresConfiguration;
 

--- a/src/Annotation/EloquaAppCloudInteractiveResponder.php
+++ b/src/Annotation/EloquaAppCloudInteractiveResponder.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines a Eloqua AppCloud Decision Responder item annotation object.
+ *
+ * @see \Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderManager
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class EloquaAppCloudInteractiveResponder extends Plugin {
+
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The label of the plugin.
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   *
+   * @ingroup plugin_translatable
+   */
+  public $label;
+
+  /**
+   * The list of fields required by the plugin.
+   *
+   * @var array
+   *
+   */
+  public $fieldList;
+
+  /**
+   * The API type (contacts or customObject).
+   * @var string
+   */
+  public $api;
+
+
+  /**
+   * The name of the queue worker this plugin requires.
+   * @var string
+   */
+  public $queueWorker;
+
+  /**
+   * The tye of response this piugin expects (either synchronous or asynchronous.
+   *
+   * @var string
+   */
+  public $respond;
+
+  /**
+   * The description of this plugin. It will be returned to Eloqua on update requests.
+   * @var string
+   */
+  public $description;
+
+}

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -247,13 +247,13 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $response = [];
       // Is this a sync or async (bulk) plugin? If the annotation is empty then assume that it is async.
       if(empty($plugin->respond) || $plugin->respond === 'asynchronous'){
-        $response = respondAsynchronously($plugin, $records, $instanceId);
+        $response = $this->respondAsynchronously($plugin, $records, $instanceId);
         $json = new JsonResponse($response);
         $json->setStatusCode(204);
       }elseif($plugin->respond === 'synchronous'){
         // Merge all the responses into one array.
         // TODO: Will this even work?
-        $response = array_merge($response, respondSynchronously($plugin, $records, $instanceId));
+        $response = array_merge($response, $this->respondSynchronously($plugin, $records, $instanceId));
         $json = new JsonResponse($response);
         $json->setStatusCode(200);
       }

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -9,6 +9,7 @@ use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Render\HtmlResponse;
 use Drupal\Core\Render\Renderer;
+use Drupal\eloqua_app_cloud\Exception\EloquaAppCloudApiException;
 use Drupal\eloqua_app_cloud\Exception\EloquaAppCloudInstanceIdNotFoundException;
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudInteractiveResponderBase;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
@@ -22,7 +23,7 @@ use Symfony\Component\HttpFoundation\Response;
 /**
  * Class EndpointControllerBase.
  *
- * @property  pluginManagerService
+ * @property pluginManagerService
  * @package Drupal\eloqua_app_cloud\Controller
  */
 class EloquaAppCloudEndpointController extends ControllerBase {
@@ -187,6 +188,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       // We can only allow ONE type of API at a time.
       if (!empty($api) && $api !== $plugin->api()) {
         // Throw an exception!
+        throw new EloquaAppCloudApiException('Multiple API types found, only one allowed (i.e. contacts or Custom Objects).');
       }
       $api = $plugin->api();
       // Merge the required field lists of all the listed plugins.

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -176,6 +176,8 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @param $pluginReferences
    *
    * @return array
+   *
+   * @throws \Drupal\eloqua_app_cloud\Exception\EloquaAppCloudApiException
    */
   private function getFieldList($pluginReferences) {
     // Iterate over the ServiceEntity plugins and build a merged field list.

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -253,7 +253,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       }elseif($plugin->respond === 'synchronous'){
         // Merge all the responses into one array.
         // TODO: Will this even work?
-        $response = array_merge($response, $this->respondSynchronously($plugin, $records, $instanceId));
+        $response = array_merge($response, $this->respondSynchronously($plugin, $records, $instanceId, $executionId));
         $json = new JsonResponse($response);
         $json->setStatusCode(200);
       }
@@ -261,6 +261,11 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     return $json;
   }
 
+  /**
+   * @param $eloqua_app_cloud_service
+   *
+   * @return mixed
+   */
   private function getEntityPlugins($eloqua_app_cloud_service){
     //Get the service entity defined at this route.
     $entity = $this->entityManager->getStorage('eloqua_app_cloud_service')
@@ -269,6 +274,11 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     return $entity->field_eloqua_app_cloud_responder->getIterator();
   }
 
+  /**
+   * @param $pluginReferences
+   *
+   * @return array
+   */
   private function getFieldList($pluginReferences){
     // Iterate over the ServiceEntity plugins and build a merged field list.
     $fieldLists = [];
@@ -290,6 +300,14 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     return $fieldLists;
   }
 
+  /**
+   * @param $plugin
+   * @param $records
+   * @param $instanceId
+   * @param $executionId
+   *
+   * @return \stdClass
+   */
   protected function respondAsynchronously($plugin, $records, $instanceId, $executionId){
     /**
      * Get the appropriate queue for this plugin.
@@ -319,7 +337,14 @@ class EloquaAppCloudEndpointController extends ControllerBase {
 
   }
 
-  protected function respondSynchronously($plugin, $records, $instanceId){
+  /**
+   * @param $plugin
+   * @param $records
+   * @param $instanceId
+   *
+   * @return \stdClass
+   */
+  protected function respondSynchronously($plugin, $records, $instanceId, $executionId){
     $response = new \stdClass();
     // The response
     $response = $plugin->execute();

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -125,7 +125,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @return mixed
    */
   public function instantiate($eloqua_app_cloud_service) {
-    $query = $this->request->all();
+    $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $instanceId = $query["instance"];
     if (empty($instanceId)) {
@@ -206,7 +206,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @return mixed
    */
   public function update($eloqua_app_cloud_service) {
-    $query = $this->request->all();
+    $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $query["instance"];
     if (empty($instanceId)) {
@@ -242,9 +242,9 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @return mixed
    */
   public function delete($eloqua_app_cloud_service) {
-    //
+    $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
-    $instanceId = $this->request->get("instance");
+    $instanceId = $query["instance"];
     if (empty($instanceId)) {
       $this->logger->error('No instanceID found');
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
@@ -281,7 +281,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @return mixed
    */
   public function execute($eloqua_app_cloud_service) {
-    $query = $this->request->all();
+    $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $query["instance"];
     if (empty($instanceId)) {
@@ -351,7 +351,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
   function respondSynchronously($plugin, $records, $instanceId, $executionId, $query) {
     $response = new \stdClass();
     // The response will be the same for all contacts, but we need one "record".
-    $response = $plugin->execute($instanceId, new \stdClass());
+    $response = $plugin->execute($instanceId, new \stdClass(), $query);
     return $response;
   }
 
@@ -374,7 +374,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     // Put the records directly onto on the queue.
     foreach ($records as $record) {
       // Let the plugin manipulate the record as needed.
-      $plugin->execute($instanceId, $record);
+      $plugin->execute($instanceId, $record, $query);
     }
     // @TODO Define a queueItem class?
     $queueItem = new \stdClass();

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -2,7 +2,6 @@
 
 namespace Drupal\eloqua_app_cloud\Controller;
 
-use Drupal\Component\Plugin\PluginManagerInterface;
 use Drupal\Core\Cache\CacheableResponse;
 use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Entity\EntityTypeManager;
@@ -11,8 +10,6 @@ use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
 use Drupal\Core\Render\Renderer;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
-use Drupal\rest\ResourceResponse;
-use Guzzle\Http\Message\Response;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -257,7 +254,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
         // TODO: Will this even work?
         $response = $this->respondSynchronously($plugin, $records, $instanceId, $executionId);
         $responseHtml = $this->renderer->renderRoot($response);
-        $result = new ResourceResponse($responseHtml);
+        $result = new CacheableResponse($responseHtml);
         $result->addCacheableDependency($response);
         return $result;
 

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -143,7 +143,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $pluginMgr = $this->plugins[$id];
       // Instantiate the referenced plugin.
       $plugin = $pluginMgr->createInstance($id);
-      $instantiate = $plugin->instantiate();
+      $instantiate = $plugin->instantiate($instanceId);
     }
 
     $this->logger->debug('Received instantiate service hook with payload @fieldList', [
@@ -227,7 +227,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $pluginMgr = $this->plugins[$id];
       // Instantiate the referenced plugin.
       $plugin = $pluginMgr->createInstance($id);
-      $update = $plugin->update();
+      $update = $plugin->update($instanceId);
       $response['#content'][$plugin->getPluginId()] = $update;
     }
     return $response;
@@ -316,7 +316,6 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $pluginMgr = $this->plugins[$id];
       // Instantiate the referenced plugin.
       $plugin = $pluginMgr->createInstance($id);
-      $response = [];
       // Is this a sync or async (bulk) plugin? If the annotation is empty then assume that it is async.
       if (!empty($plugin->respond()) && $plugin->respond() === 'synchronous') {
         $this->logger->debug('The @plugin plugin requested a synchronous response.', ['@plugin' => $plugin->getPluginId()]);
@@ -349,7 +348,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
   function respondSynchronously($plugin, $records, $instanceId, $executionId) {
     $response = new \stdClass();
     // The response will be the same for all contacts, but we need one "record".
-    $response = $plugin->execute(new \stdClass());
+    $response = $plugin->execute($instanceId, new \stdClass());
     return $response;
   }
 
@@ -372,7 +371,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     // Put the records directly onto on the queue.
     foreach ($records as $record) {
       // Let the plugin manipulate the record as needed.
-      $plugin->execute($record);
+      $plugin->execute($instanceId, $record);
     }
     // @TODO Define a queueItem class?
     $queueItem = new \stdClass();

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -57,10 +57,14 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    */
   protected $plugins;
 
-  /** @var  LoggerInterface */
+  /**
+   * @var  LoggerInterface
+   */
   protected $logger;
 
-  /** @var \Drupal\Core\Render\Renderer */
+  /**
+   * @var \Drupal\Core\Render\Renderer
+   */
   protected $renderer;
 
   /**
@@ -122,17 +126,15 @@ class EloquaAppCloudEndpointController extends ControllerBase {
   /**
    * Instantiate and store the instance ID from Eloqua.
    *
+   * @param $eloquaAppCloudService
+   *
    * @return mixed
    */
   public function instantiate($eloquaAppCloudService) {
     $query = $this->request->query->all();
+
     // Get the instanceID from the query parameter.
-    $instanceId = $instanceId = $query["instance"];
-    if (empty($instanceId)) {
-      $this->logger->error('No instanceID found');
-      // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
-      return new HtmlResponse('No instanceID found.', 500);
-    }
+    $instanceId = $this->getInstanceId($query);
     $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     // Punting on the case where there are multiple plugins for a service.
@@ -188,7 +190,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
         // Throw an exception!
       }
       $api = $plugin->api();
-      // Merge the required fieldlists of all the listed plugins.
+      // Merge the required field lists of all the listed plugins.
       $fieldLists = array_merge($fieldLists, $plugin->fieldList());
     }
     return $fieldLists;
@@ -209,12 +211,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
   public function update($eloquaAppCloudService) {
     $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
-    $instanceId = $query["instance"];
-    if (empty($instanceId)) {
-      $this->logger->error('No instanceID found');
-      // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
-      return new HtmlResponse('No instanceID found.', 500);
-    }
+    $instanceId = $this->getInstanceId($query);
     $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     $response = [
@@ -245,12 +242,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
   public function delete($eloquaAppCloudService) {
     $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
-    $instanceId = $query["instance"];
-    if (empty($instanceId)) {
-      $this->logger->error('No instanceID found');
-      // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
-      return new HtmlResponse('No instanceID found.', 500);
-    }
+    $instanceId = $this->getInstanceId($query);
     $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     // Iterate over the ServiceEntity plugins and then over the payload items.
@@ -284,13 +276,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    */
   public function execute($eloquaAppCloudService) {
     $query = $this->request->query->all();
-    // Get the instanceID from the query parameter.
-    $instanceId = $query["instance"];
-    if (empty($instanceId)) {
-      $this->logger->error('No instanceID found for service @eloqua_app_cloud_service.', ['@eloqua_app_cloud_service' => $eloquaAppCloudService]);
-      // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
-      return new HtmlResponse('No instanceID found.', 500);
-    }
+    $instanceId = $this->getInstanceId($query);
     // Get the execution ID
     $executionId = $this->request->get("executionId");
     if (empty($executionId)) {
@@ -402,16 +388,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    *
    * @return string
    */
-  public
-  function getTitle($eloquaAppCloudService = NULL) {
-    // Get the instanceID from the query parameter.
-    $instanceId = $this->request->get("instance");
-    $this->logger->debug('Got instance ID @instance.', ['@instance' => $instanceId]);
-    if (empty($instanceId)) {
-      $this->logger->error('No instanceID found');
-      // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
-      return new HtmlResponse('No instanceID found.', 500);
-    }
+  public function getTitle($eloquaAppCloudService = NULL) {
     $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
     $title = "";
     foreach ($pluginReferences as $pluginReference) {
@@ -425,5 +402,20 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $title .= ' ' . $plugin->label();
     }
     return $title;
+  }
+
+  /**
+   * @param $query
+   *
+   * @return $instanceId
+   */
+  private function getInstanceId($query) {
+    $instanceId = $query["instance"];
+    if (empty($instanceId)) {
+      $this->logger->error('No instanceID found');
+      // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
+      return new HtmlResponse('No instanceID found.', 500);
+    }
+    return $instanceId;
   }
 }

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -258,7 +258,6 @@ class EloquaAppCloudEndpointController extends ControllerBase {
         $json->setStatusCode(200);
       }
     }
-
     return $json;
   }
 

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -150,7 +150,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     }
     $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
 
-    $fieldList = $this.$this->getFieldList($pluginReferences);
+    $fieldList = $this->getFieldList($pluginReferences);
 
     $response = new \stdClass();
     $response->recordDefinition = $fieldList;

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -150,6 +150,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       '@fieldList' => print_r($this->getFieldList($pluginReferences), TRUE),
     ]);
 
+    // @TODO: Make response code explicit (200)
     return new JsonResponse($instantiate);
   }
 

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -360,7 +360,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     // @TODO Define a queueItem class?
     $queueItem = new \stdClass();
     // Pass the queue type to the worker to make it easy to requeue if there are more then 5000 records.
-    $queueItem->queueId = $plugin->queueWorker();
+    $queueItem->queueWorker = $plugin->queueWorker();
     // Pass the instance ID and Execution ID so the worker can communicate with Eloqua.
     $queueItem->instanceId = $instanceId;
     $queueItem->executionId = $executionId;

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -247,7 +247,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $response = [];
       // Is this a sync or async (bulk) plugin? If the annotation is empty then assume that it is async.
       if(empty($plugin->respond) || $plugin->respond === 'asynchronous'){
-        $response = $this->respondAsynchronously($plugin, $records, $instanceId);
+        $response = $this->respondAsynchronously($plugin, $records, $instanceId, $executionId);
         $json = new JsonResponse($response);
         $json->setStatusCode(204);
       }elseif($plugin->respond === 'synchronous'){
@@ -290,7 +290,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     return $fieldLists;
   }
 
-  protected function respondAsynchronously($plugin, $records, $instanceId){
+  protected function respondAsynchronously($plugin, $records, $instanceId, $executionId){
     /**
      * Get the appropriate queue for this plugin.
      * @var QueueInterface $queue
@@ -305,11 +305,10 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     $queueItem = new \stdClass();
     // Pass the queue type to the worker to make it easy to requeue if there are more then 5000 records.
     $queueItem->queueId = $plugin->queueWorker();
-    // Pass the instance ID so the worker can communicate with Eloqua.
+    // Pass the instance ID and Execution ID so the worker can communicate with Eloqua.
     $queueItem->instanceId = $instanceId;
-    if(!empty($executionId)){
-      $queueItem->executionId = $executionId;
-    }
+    $queueItem->executionId = $executionId;
+
     $queueItem->api = $plugin->api();
     $queueItem->fieldList = $plugin->fieldList();
     $queueItem->records = $records;

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Entity\EntityTypeManager;
 use Drupal\Core\Language\LanguageManagerInterface;
 use Drupal\Core\Queue\QueueFactory;
 use Drupal\Core\Queue\QueueInterface;
+use Drupal\Core\Render\HtmlResponse;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -245,13 +246,14 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $response = [];
       // Is this a sync or async (bulk) plugin? If the annotation is empty then assume that it is async.
       if(!empty($plugin->respond) && $plugin->respond === 'synchronous'){
+        $this->logger->debug('Synchronous');
         // Merge all the responses into one array.
         // TODO: Will this even work?
-        $response = array_merge($response, $this->respondSynchronously($plugin, $records, $instanceId, $executionId));
-        $json = new JsonResponse($response);
+        $response = $this->respondSynchronously($plugin, $records, $instanceId, $executionId);
+        $json = new HtmlResponse($response);
         $json->setStatusCode(200);
-
       }else{
+        $this->logger->debug('Asynchronous');
         $response = $this->respondAsynchronously($plugin, $records, $instanceId, $executionId);
         $json = new JsonResponse($response);
         $json->setStatusCode(204);

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -245,7 +245,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $plugin = $pluginMgr->createInstance($id);
       $response = [];
       // Is this a sync or async (bulk) plugin? If the annotation is empty then assume that it is async.
-      if(!empty($plugin->respond) && $plugin->respond === 'synchronous'){
+      if(!empty($plugin->respond()) && $plugin->respond() === 'synchronous'){
         $this->logger->debug('Synchronous');
         // Merge all the responses into one array.
         // TODO: Will this even work?

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -124,7 +124,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    *
    * @return mixed
    */
-  public function instantiate($eloqua_app_cloud_service) {
+  public function instantiate($eloquaAppCloudService) {
     $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $instanceId = $query["instance"];
@@ -133,7 +133,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
       return new HtmlResponse('No instanceID found.', 500);
     }
-    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+    $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     // Punting on the case where there are multiple plugins for a service.
     // This code will always return the instantiate response for the last plugin in the list.
@@ -151,19 +151,19 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     ]);
 
     // @TODO: Make response code explicit (200)
-    return new JsonResponse($instantiate);
+    return new JsonResponse($instantiate, 200);
   }
 
   /**
-   * @param $eloqua_app_cloud_service
+   * @param $eloquaAppCloudService
    *
    * @return mixed
    */
   private
-  function getEntityPlugins($eloqua_app_cloud_service) {
+  function getEntityPlugins($eloquaAppCloudService) {
     //Get the service entity defined at this route.
     $entity = $this->entityManager->getStorage('eloqua_app_cloud_service')
-      ->load($eloqua_app_cloud_service);
+      ->load($eloquaAppCloudService);
     // Return the list of plugin references.
     return $entity->field_eloqua_app_cloud_responder->getIterator();
   }
@@ -202,11 +202,11 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @TODO: implement a way to request an updated field list :)
    *   (https://github.com/tableau-mkt/eloqua_app_cloud/issues/3)
    *
-   * @param $eloqua_app_cloud_service
+   * @param $eloquaAppCloudService
    *
    * @return mixed
    */
-  public function update($eloqua_app_cloud_service) {
+  public function update($eloquaAppCloudService) {
     $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $query["instance"];
@@ -215,7 +215,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
       return new HtmlResponse('No instanceID found.', 500);
     }
-    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+    $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     $response = [
       '#theme' => 'eloqua_app_cloud_update',
@@ -242,7 +242,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    *   of doing it here.
    * @return mixed
    */
-  public function delete($eloqua_app_cloud_service) {
+  public function delete($eloquaAppCloudService) {
     $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $query["instance"];
@@ -251,7 +251,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
       return new HtmlResponse('No instanceID found.', 500);
     }
-    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+    $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     // Iterate over the ServiceEntity plugins and then over the payload items.
     foreach ($pluginReferences as $pluginReference) {
@@ -274,6 +274,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
         }
       }
     }
+    return new HtmlResponse('Deleted.', 200);
   }
 
   /**
@@ -281,19 +282,19 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    *
    * @return mixed
    */
-  public function execute($eloqua_app_cloud_service) {
+  public function execute($eloquaAppCloudService) {
     $query = $this->request->query->all();
     // Get the instanceID from the query parameter.
     $instanceId = $query["instance"];
     if (empty($instanceId)) {
-      $this->logger->error('No instanceID found for service @eloqua_app_cloud_service.', ['@eloqua_app_cloud_service' => $eloqua_app_cloud_service]);
+      $this->logger->error('No instanceID found for service @eloqua_app_cloud_service.', ['@eloqua_app_cloud_service' => $eloquaAppCloudService]);
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
       return new HtmlResponse('No instanceID found.', 500);
     }
     // Get the execution ID
     $executionId = $this->request->get("executionId");
     if (empty($executionId)) {
-      $this->logger->error('No executionId found for @eloqua_app_cloud_service.', ['@eloqua_app_cloud_service' => $eloqua_app_cloud_service]);
+      $this->logger->error('No executionId found for @eloqua_app_cloud_service.', ['@eloqua_app_cloud_service' => $eloquaAppCloudService]);
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
       return new HtmlResponse('No executionId found.', 500);
     }
@@ -311,7 +312,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     $this->logger->debug('Received execute service hook with payload @records', [
       '@record' => print_r($records, TRUE),
     ]);
-    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+    $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     // Iterate over the ServiceEntity plugins and then over the payload items.
     foreach ($pluginReferences as $pluginReference) {
@@ -402,7 +403,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    * @return string
    */
   public
-  function getTitle($eloqua_app_cloud_service = NULL) {
+  function getTitle($eloquaAppCloudService = NULL) {
     // Get the instanceID from the query parameter.
     $instanceId = $this->request->get("instance");
     $this->logger->debug('Got instance ID @instance.', ['@instance' => $instanceId]);
@@ -411,7 +412,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       // It apparently does not matter what we return here, since Eloqua does not have any way of handing external errors?
       return new HtmlResponse('No instanceID found.', 500);
     }
-    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+    $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
     $title = "";
     foreach ($pluginReferences as $pluginReference) {
       $id = $pluginReference->value;

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -1,0 +1,303 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Controller;
+
+use Drupal\Component\Plugin\PluginManagerInterface;
+use Drupal\Core\Controller\ControllerBase;
+use Drupal\Core\Entity\EntityTypeManager;
+use Drupal\Core\Language\LanguageManagerInterface;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Drupal\eloqua_rest_api\Factory\ClientFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\JsonResponse;
+use Symfony\Component\HttpFoundation\RequestStack;
+
+
+/**
+ * Class EndpointControllerBase.
+ *
+ * @property  pluginManagerService
+ * @package Drupal\eloqua_app_cloud\Controller
+ */
+class EloquaAppCloudEndpointController extends ControllerBase {
+
+
+  /**
+   * @var string
+   *
+   */
+  protected $eloquaInstanceId;
+
+  /**
+   * @var \Eloqua\Client
+   */
+  protected $eloqua;
+
+  /**
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * @var LanguageManagerInterface
+   */
+  protected $langManager;
+
+  /**
+   * @var EntityTypeManager
+   */
+  protected $entityManager;
+
+  /**
+   * @var QueueFactory
+   */
+  protected $queueFactory;
+
+  /**
+   * @var array $plugins
+   */
+  protected $plugins;
+
+
+  /**
+   * EndpointControllerBase constructor.
+   *
+   * @param \Drupal\eloqua_app_cloud\Controller\ClientFactory|\Drupal\eloqua_rest_api\Factory\ClientFactory $eloquaFactory
+   * @param \Drupal\eloqua_app_cloud\Controller\RequestStack|\Symfony\Component\HttpFoundation\RequestStack $requestStack
+   * @param \Drupal\Core\Language\LanguageManagerInterface $langManager
+   * @param \Drupal\Core\Entity\EntityTypeManager $entityManager
+   * @param \Drupal\Core\Queue\QueueFactory $queue
+   * @param $plugins
+   */
+  public function __construct(ClientFactory $eloquaFactory, RequestStack $requestStack, LanguageManagerInterface $langManager, EntityTypeManager $entityManager, QueueFactory $queueFactory,array $plugins) {
+    $this->eloqua = $eloquaFactory->get();
+    $this->request = $requestStack->getCurrentRequest();
+    $this->langManager = $langManager;
+    $this->entityManager = $entityManager;
+    $this->queueFactory = $queueFactory;
+    $this->plugins = $plugins;
+  }
+
+  /**
+   * @param \Symfony\Component\DependencyInjection\ContainerInterface $container
+   *
+   * @return static
+   */
+  public static function create(ContainerInterface $container) {
+
+    // Get the list of plugin managers in our "namespace".
+    foreach ($container->getServiceIds() as $serviceId) {
+      if (strpos($serviceId, 'plugin.manager.eloqua_app_cloud') === 0) {
+        $type = $container->get($serviceId);
+        $plugin_definitions = $type->getDefinitions();
+
+        foreach ($plugin_definitions as $plugin) {
+          $plugins[$plugin['id']] = $type;
+        }
+      }
+    }
+
+    return new static(
+      $container->get('eloqua.client_factory'),
+      $container->get('request_stack'),
+      $container->get('language_manager'),
+      $container->get('entity_type.manager'),
+      $container->get('queue'),
+      $plugins
+    );
+  }
+
+  /**
+   * Instantiate and store the instance ID from Eloqua.
+   *
+   * @return \Drupal\eloqua_app_cloud\Controller\JsonResponse
+   */
+  public function instantiate($eloqua_app_cloud_service) {
+    // Get the instanceID from the query parameter.
+    $instanceId = $this->request->get("instance");
+    if (empty($instanceId)) {
+      //Throw an exception, and/or return an error?
+    }
+    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+
+    // Iterate over the ServiceEntity plugins and build a merged field list.
+    foreach ($pluginReferences as $pluginReference) {
+      $id = $pluginReference->value;
+      // Get the plugin manager from the list of plugins (from the container).
+      $pluginMgr = $this->plugins[$id];
+      // Instantiate the referenced plugin.
+      $plugin = $pluginMgr->createInstance($id);
+      // We can only allow ONE type of API at a time.
+      if(!empty($api) && $api !== $plugin->api()){
+        // @TODO Throw an exception!
+      }
+      $api = $plugin->api();
+      // @TODO figure out how to determine field list? This pulls it from annotation, but maybe it should be in config so it can be customized?
+      $fieldList = $plugin->fieldList();
+      $fieldList = array_merge($fieldList, $plugin->fieldList());
+    }
+
+    $response = new \stdClass();
+    $response->recordDefinition = $fieldList;
+    $response->requiresConfiguration = FALSE;
+    \Drupal::logger('EloquaAppCloudDecision')->notice(print_r($response, TRUE));
+    return new JsonResponse($response);
+  }
+
+  /**
+   * @param $eloqua_app_cloud_service
+   *
+   * @return \Symfony\Component\HttpFoundation\JsonResponse
+   */
+  public function update($eloqua_app_cloud_service) {
+    // Get the instanceID from the query parameter.
+    $instanceId = $this->request->get("instance");
+    if (empty($instanceId)) {
+      // @TODO Throw an exception, and/or return an error?
+    }
+    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+
+    // Iterate over the ServiceEntity plugins and build a merged field list.
+    foreach ($pluginReferences as $pluginReference) {
+      $id = $pluginReference->value;
+      // Get the plugin manager from the list of plugins (from the container).
+      $pluginMgr = $this->plugins[$id];
+      // Instantiate the referenced plugin.
+      $plugin = $pluginMgr->createInstance($id);
+      // We can only allow ONE type of API at a time.
+      if(!empty($api) && $api !== $plugin->api()){
+        // Throw an exception!
+      }
+      $api = $plugin->api();
+      // @TODO figure out how to determine field list? This pulls it from annotation, but maybe it should be in config so it can be customized?
+      $fieldList = $plugin->fieldList();
+      $fieldList = array_merge($fieldList, $plugin->fieldList());
+    }
+
+    $response = new \stdClass();
+    $response->recordDefinition = $fieldList;
+    $response->requiresConfiguration = FALSE;
+    \Drupal::logger('EloquaAppCloudDecision')->notice(print_r($response, TRUE));
+    return new JsonResponse($response);
+  }
+
+  /**
+   * Delete.
+   *
+   * @return string
+   *   Return Hello string.
+   */
+  public function delete($eloqua_app_cloud_service) {
+  // Delete any existing queue entries for this service entity.
+
+  }
+
+  /**
+   * Execute.
+   *
+   * @return string
+   *   Return Hello string.
+   */
+  public function execute($eloqua_app_cloud_service) {
+    \Drupal::logger('EloquaAppCloudDecision')->notice('Executing' );
+    // Get the instanceID from the query parameter.
+    $instanceId = $this->request->get("instance");
+    // Get the execution ID
+    $executionId = $this->request->get("executionId");
+    if (empty($instanceId)) {
+      // @TODO Throw an exception, and/or return an error?
+      return new JsonResponse(['error no instanceId']);
+    }
+    //
+    //$content = $this->mockContent();
+    // Now load the JSON payload form Eloqua.
+     $content = $this->request->getContent();
+
+    if (empty($content)) {
+      // @TODO Throw an exception, and/or return an error?
+      return new JsonResponse(['error no content']);
+    }
+    $payload = json_decode($content);
+    $records = $payload->items;
+
+    $pluginReferences = $this->getEntityPlugins($eloqua_app_cloud_service);
+
+    // Iterate over the ServiceEntity plugins and then over the payload items.
+    foreach ($pluginReferences as $pluginReference) {
+      $id = $pluginReference->value;
+      // Get the plugin manager from the list of plugins (from the container).
+      $pluginMgr = $this->plugins[$id];
+      // Instantiate the referenced plugin.
+      $plugin = $pluginMgr->createInstance($id);
+
+      /**
+       * Get the appropriate queue for this plugin.
+       * @var QueueInterface $queue
+       */
+      $queue = $this->queueFactory->get($plugin->queueWorker());
+        // Put the records directly onto on the queue.
+      foreach ($records as $record) {
+        // Put the result of the plugin on each record.
+        $record->result = $plugin->execute($record);
+      }
+      // @TODO Define a queueItem class?
+      $queueItem = new \stdClass();
+      // Pass the queue type to the worker to make it easy to requeue if there are more then 5000 records.
+      $queueItem->queueId = $plugin->queueWorker();
+      // Pass the instance ID so the worker can communicate with Eloqua.
+      $queueItem->instanceId = $instanceId;
+      if(!empty($executionId)){
+        $queueItem->executionId = $executionId;
+      }
+      $queueItem->api = $plugin->api();
+      $queueItem->fieldList = $plugin->fieldList();
+      $queueItem->records = $records;
+      $queue->createItem($queueItem);
+    }
+
+    // If we have gotten through all that we just return a 204 to indicate an asynchronous response.
+    $response = [];
+    $response['statue'] = 204;
+    return new JsonResponse($response);
+  }
+
+  private function getEntityPlugins($eloqua_app_cloud_service){
+    //Get the service entity defined at this route.
+    $entity = $this->entityManager->getStorage('eloqua_app_cloud_service')
+      ->load($eloqua_app_cloud_service);
+    // Return the list of plugin references.
+    return $entity->field_eloqua_app_cloud_responder->getIterator();
+  }
+
+  private function mockContent(){
+    $content = <<<'EOD'
+{
+    "offset" : 0,
+    "limit" : 1000,
+    "totalResults" : 2,
+    "count" : 2,
+    "hasMore" : false,
+    "items" :
+    [
+       {
+          "ContactID" : "1",
+          "EmailAddress" : "fred@example.com",
+          "field1" : "stuff",
+          "field2" : "things",
+          "field3" : "et cetera"
+       },
+       {
+          "ContactID" : "2",
+          "EmailAddress" : "john@example.com",
+          "field1" : "more stuff",
+          "field2" : "other things",
+          "field3" : "and so on"
+       }
+    ]
+}
+EOD;
+    return $content;
+  }
+
+}

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -238,8 +238,8 @@ class EloquaAppCloudEndpointController extends ControllerBase {
       $queue = $this->queueFactory->get($plugin->queueWorker());
         // Put the records directly onto on the queue.
       foreach ($records as $record) {
-        // Put the result of the plugin on each record.
-        $record->result = $plugin->execute($record);
+        // Let the plugin manipulate the record as needed.
+        $plugin->execute($record);
       }
       // @TODO Define a queueItem class?
       $queueItem = new \stdClass();

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -347,9 +347,8 @@ class EloquaAppCloudEndpointController extends ControllerBase {
    */
   protected function respondSynchronously($plugin, $records, $instanceId, $executionId){
     $response = new \stdClass();
-    // The response
-    $response = $plugin->execute();
+    // The response will be the same for all contacts, but we need one "record".
+    $response = $plugin->execute(new \stdClass());
     return $response;
   }
-
 }

--- a/src/Controller/EloquaAppCloudEndpointController.php
+++ b/src/Controller/EloquaAppCloudEndpointController.php
@@ -218,7 +218,7 @@ class EloquaAppCloudEndpointController extends ControllerBase {
     $pluginReferences = $this->getEntityPlugins($eloquaAppCloudService);
 
     $response = [
-      '#theme' => 'eloqua_app_cloud_update',
+      '#theme' => 'eloqua_app_cloud_update_dialog',
     ];
     // Punting on the case where there are multiple plugins for a service.
     // This code will always return all the instantiate responses for the

--- a/src/Entity/EloquaAppCloudServiceViewBuilder.php
+++ b/src/Entity/EloquaAppCloudServiceViewBuilder.php
@@ -58,8 +58,8 @@ class EloquaAppCloudServiceViewBuilder extends EntityViewBuilder {
       $container->get('entity.manager'),
       $container->get('language_manager'),
       $container->get('request_stack'),
-      $container->get('plugin.manager.eloqua_app_cloud_menu_responder.processor'),
-      $container->get('plugin.manager.eloqua_app_cloud_firehose_responder.processor')
+      $container->get('plugin.manager.eloqua_app_cloud.menu_responder.processor'),
+      $container->get('plugin.manager.eloqua_app_cloud.firehose_responder.processor')
     );
   }
 

--- a/src/Exceptions/EloquaAppCloudApiException.php
+++ b/src/Exceptions/EloquaAppCloudApiException.php
@@ -4,5 +4,5 @@ namespace Drupal\eloqua_app_cloud\Exception;
 
 use \Exception;
 
-class EloquaAppCloudQueueException  extends EloquaAppCloudException {
+class EloquaAppCloudApiException  extends EloquaAppCloudException {
 }

--- a/src/Exceptions/EloquaAppCloudApiException.php
+++ b/src/Exceptions/EloquaAppCloudApiException.php
@@ -4,5 +4,5 @@ namespace Drupal\eloqua_app_cloud\Exception;
 
 use \Exception;
 
-class EloquaAppCloudApiException  extends EloquaAppCloudException {
+class EloquaAppCloudApiException extends EloquaAppCloudException {
 }

--- a/src/Exceptions/EloquaAppCloudException.php
+++ b/src/Exceptions/EloquaAppCloudException.php
@@ -4,5 +4,5 @@ namespace Drupal\eloqua_app_cloud\Exception;
 
 use \Exception;
 
-class EloquaAppCloudException  extends Exception {
+class EloquaAppCloudException extends Exception {
 }

--- a/src/Exceptions/EloquaAppCloudException.php
+++ b/src/Exceptions/EloquaAppCloudException.php
@@ -1,10 +1,4 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: jkopel
- * Date: 11/8/17
- * Time: 3:09 PM
- */
 
 namespace Drupal\eloqua_app_cloud\Exception;
 

--- a/src/Exceptions/EloquaAppCloudException.php
+++ b/src/Exceptions/EloquaAppCloudException.php
@@ -1,0 +1,15 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: jkopel
+ * Date: 11/8/17
+ * Time: 3:09 PM
+ */
+
+namespace Drupal\eloqua_app_cloud\Exception;
+
+use \Exception;
+
+class EloquaAppCloudException  extends Exception {
+
+}

--- a/src/Exceptions/EloquaAppCloudQueueException.php
+++ b/src/Exceptions/EloquaAppCloudQueueException.php
@@ -10,5 +10,5 @@ namespace Drupal\eloqua_app_cloud\Exception;
 
 use \Exception;
 
-class EloquaAppCloudException  extends Exception {
+class EloquaAppCloudQueueException  extends EloquaAppCloudException {
 }

--- a/src/Exceptions/EloquaAppCloudQueueException.php
+++ b/src/Exceptions/EloquaAppCloudQueueException.php
@@ -4,5 +4,5 @@ namespace Drupal\eloqua_app_cloud\Exception;
 
 use \Exception;
 
-class EloquaAppCloudQueueException  extends EloquaAppCloudException {
+class EloquaAppCloudQueueException extends EloquaAppCloudException {
 }

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  id = "ActionDebugResponder",
  *  label = @Translation("Action Debug Responder"),
  *  api = "contacts",
+ *  respond = "asynchronous",
  *  queueWorker = "eloqua_app_cloud_action_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *   requiresConfiguration = "false"
+ *  requiresConfiguration = "false"
  * )
  */
 class DebugResponder extends EloquaAppCloudActionResponderBase implements EloquaAppCloudActionResponderInterface {

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponder;
 
+use Drupal\Core\Lock\NullLockBackend;
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderBase;
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderInterface;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
@@ -53,7 +54,7 @@ class DebugResponder extends EloquaAppCloudActionResponderBase implements Eloqua
   /**
    * {@inheritdoc}
    */
-  public function execute($instanceId, $record) {
+  public function execute($instanceId, $record, $query = NULL) {
     $this->logger->debug('Received action service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -18,7 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  queueWorker = "eloqua_app_cloud_action_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
- *   }
+ *   },
+ *   requiresConfiguration = "false"
  * )
  */
 class DebugResponder extends EloquaAppCloudActionResponderBase implements EloquaAppCloudActionResponderInterface {

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -1,24 +1,24 @@
 <?php
 
-namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponder;
+namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponder;
 
-use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderBase;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @EloquaAppCloudDecisionResponder(
- *  id = "DecisionDebugResponder",
- *  label = @Translation("Decision Debug Responder"),
+ * @EloquaAppCloudActionResponder(
+ *  id = "ActionDebugResponder",
+ *  label = @Translation("Action Debug Responder"),
  *  api = "contacts",
- *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
+ *  queueWorker = "eloqua_app_cloud_action_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   }
  * )
  */
-class DebugResponder extends EloquaAppCloudDecisionResponderBase {
+class DebugResponder extends EloquaAppCloudActionResponderBase {
 
   /**
    * @var LoggerInterface
@@ -50,15 +50,9 @@ class DebugResponder extends EloquaAppCloudDecisionResponderBase {
    * {@inheritdoc}
    */
   public function execute($record) {
-    $this->logger->debug('Received decision service hook with payload @record', [
+    $this->logger->debug('Received action service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);
-    if($record->EmailAddress == "jkopel@tableau.com"){
-      $record->result = FALSE;
-    }else {
-      $record->result = TRUE;
-    }
     return $record;
   }
-
 }

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -20,7 +20,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *  requiresConfiguration = "false"
+ *  requiresConfiguration = FALSE
  * )
  */
 class DebugResponder extends EloquaAppCloudActionResponderBase implements EloquaAppCloudActionResponderInterface {

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -3,6 +3,7 @@
 namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponder;
 
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderInterface;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -11,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudActionResponder(
  *  id = "ActionDebugResponder",
  *  label = @Translation("Action Debug Responder"),
+ *  description = "Simple synchronous content debugging tool that always returns the same HTML for every record",
  *  api = "contacts",
  *  respond = "asynchronous",
  *  queueWorker = "eloqua_app_cloud_action_queue_worker",
@@ -19,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponder extends EloquaAppCloudActionResponderBase {
+class DebugResponder extends EloquaAppCloudActionResponderBase implements EloquaAppCloudActionResponderInterface {
 
   /**
    * @var LoggerInterface

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -16,7 +16,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  description = "Simple synchronous content debugging tool that always returns the same HTML for every record",
  *  api = "contacts",
  *  respond = "asynchronous",
- *  queueWorker = "eloqua_app_cloud_action_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },

--- a/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudActionResponder/DebugResponder.php
@@ -53,7 +53,7 @@ class DebugResponder extends EloquaAppCloudActionResponderBase implements Eloqua
   /**
    * {@inheritdoc}
    */
-  public function execute($record) {
+  public function execute($instanceId, $record) {
     $this->logger->debug('Received action service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudActionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudActionResponderBase.php
@@ -6,5 +6,12 @@ namespace Drupal\eloqua_app_cloud\Plugin;
  * Base class for Eloqua AppCloud Action Responder plugins.
  */
 abstract class EloquaAppCloudActionResponderBase extends EloquaAppCloudInteractiveResponderBase {
-  // Add common methods and abstract methods for your plugin type here.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function queueWorker() {
+    // Return a valid queueWorker for this plugin class.
+    return "eloqua_app_cloud_action_queue_worker";
+  }
 }

--- a/src/Plugin/EloquaAppCloudActionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudActionResponderBase.php
@@ -5,37 +5,6 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 /**
  * Base class for Eloqua AppCloud Action Responder plugins.
  */
-abstract class EloquaAppCloudActionResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudActionResponderInterface {
-
+abstract class EloquaAppCloudActionResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
-
-  /**
-   * {@inheritdoc}
-   */
-  public function api() {
-    // Retrieve the @api property from the annotation and return it.
-    return (string) $this->pluginDefinition['api'];
-  }
-  /**
-   * {@inheritdoc}
-   */
-  public function fieldList() {
-    // Retrieve the @fieldList property from the annotation and return it.
-    return (array) $this->pluginDefinition['fieldList'];
-  }
-  /**
-   * {@inheritdoc}
-   */
-  public function queueWorker() {
-    // Retrieve the @queueWorker property from the annotation and return it.
-    return (string) $this->pluginDefinition['queueWorker'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function respond() {
-    // Retrieve the @respond property from the annotation and return it.
-    return (string) $this->pluginDefinition['respond'];
-  }
 }

--- a/src/Plugin/EloquaAppCloudActionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudActionResponderBase.php
@@ -30,4 +30,12 @@ abstract class EloquaAppCloudActionResponderBase extends EloquaAppCloudResponder
     // Retrieve the @queueWorker property from the annotation and return it.
     return (string) $this->pluginDefinition['queueWorker'];
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function respond() {
+    // Retrieve the @respond property from the annotation and return it.
+    return (string) $this->pluginDefinition['respond'];
+  }
 }

--- a/src/Plugin/EloquaAppCloudActionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudActionResponderBase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+/**
+ * Base class for Eloqua AppCloud Action Responder plugins.
+ */
+abstract class EloquaAppCloudActionResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudActionResponderInterface {
+
+  // Add common methods and abstract methods for your plugin type here.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function api() {
+    // Retrieve the @api property from the annotation and return it.
+    return (string) $this->pluginDefinition['api'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function fieldList() {
+    // Retrieve the @fieldList property from the annotation and return it.
+    return (array) $this->pluginDefinition['fieldList'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function queueWorker() {
+    // Retrieve the @queueWorker property from the annotation and return it.
+    return (string) $this->pluginDefinition['queueWorker'];
+  }
+}

--- a/src/Plugin/EloquaAppCloudActionResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudActionResponderInterface.php
@@ -7,40 +7,5 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 /**
  * Defines an interface for Eloqua AppCloud Action Responder plugins.
  */
-interface EloquaAppCloudActionResponderInterface extends PluginInspectionInterface {
-
-  /**
-   * Method that gets executed when a Action Service is invoked from within the
-   * Eloqua UI.
-   *
-   * @param object $record
-   * object jsondecoded from Eloqua transmission.
-   *
-   * @return null
-   */
-  public function execute($record);
-
-  /**
-   * @return array
-   *    The list of fields this plugin needs from Eloqua.
-   */
-  public function fieldList();
-  /**
-   * @return string
-   *    The API type (contacts or customObject)
-   */
-  public function api();
-
-  /**
-   * @return string
-   *     The name of the queue worker plugin this plugin requires.
-   */
-  public function queueWorker();
-
-  /**
-   * @return string
-   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
-   */
-  public function respond();
-
+interface EloquaAppCloudActionResponderInterface extends EloquaAppCloudInteractiveResponderInterface {
 }

--- a/src/Plugin/EloquaAppCloudActionResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudActionResponderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Eloqua AppCloud Action Responder plugins.
+ */
+interface EloquaAppCloudActionResponderInterface extends PluginInspectionInterface {
+
+  /**
+   * Method that gets executed when a Action Service is invoked from within the
+   * Eloqua UI.
+   *
+   * @param object $record
+   * object jsondecoded from Eloqua transmission.
+   *
+   * @return null
+   */
+  public function execute($record);
+
+  /**
+   * @return array
+   *    The list of fields this plugin needs from Eloqua.
+   */
+  public function fieldList();
+  /**
+   * @return string
+   *    The API type (contacts or customObject)
+   */
+  public function api();
+
+  /**
+   * @return string
+   *     The name of the queue worker plugin this plugin requires.
+   */
+  public function queueWorker();
+
+}

--- a/src/Plugin/EloquaAppCloudActionResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudActionResponderInterface.php
@@ -37,4 +37,10 @@ interface EloquaAppCloudActionResponderInterface extends PluginInspectionInterfa
    */
   public function queueWorker();
 
+  /**
+   * @return string
+   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
+   */
+  public function respond();
+
 }

--- a/src/Plugin/EloquaAppCloudActionResponderManager.php
+++ b/src/Plugin/EloquaAppCloudActionResponderManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides the Eloqua AppCloud Action Responder plugin manager.
+ */
+class EloquaAppCloudActionResponderManager extends DefaultPluginManager {
+
+  /**
+   * Constructor for EloquaAppCloudActionResponderManager objects.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/EloquaAppCloudActionResponder', $namespaces, $module_handler, 'Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudActionResponderInterface', 'Drupal\eloqua_app_cloud\Annotation\EloquaAppCloudActionResponder');
+
+    $this->alterInfo('eloqua_app_cloud_eloqua_app_cloud_action_responder_info');
+    $this->setCacheBackend($cache_backend, 'eloqua_app_cloud_eloqua_app_cloud_action_responder_plugins');
+  }
+
+}

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -1,24 +1,25 @@
 <?php
 
-namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponder;
+namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponder;
 
-use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderBase;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @EloquaAppCloudDecisionResponder(
- *  id = "DecisionDebugResponderYes",
- *  label = @Translation("Decision Debug Responder (yes)"),
+ * @EloquaAppCloudContentResponder(
+ *  id = "ContentDebugResponder",
+ *  label = @Translation("Asynchronous Content Debug Responder"),
+ *  respond = 'asynchronous',
  *  api = "contacts",
- *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
+ *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   }
  * )
  */
-class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
+class DebugResponderAsync extends EloquaAppCloudContentResponderBase {
 
   /**
    * @var LoggerInterface
@@ -50,10 +51,9 @@ class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
    * {@inheritdoc}
    */
   public function execute($record) {
-    $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is YES', [
+    $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);
-    $record->result = TRUE;
-    return $record;
+    return "<div>DEBUG CONTENT</div>";
   }
 }

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -19,10 +19,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *   requiresConfiguration = "false",
- *   height = "",
- *   width = "",
- *   editorImageUrl = ""
+ *  requiresConfiguration = "false",
+ *  height = "",
+ *  width = "",
+ *  editorImageUrl = ""
  * )
  */
 class DebugResponderAsync extends EloquaAppCloudContentResponderBase implements EloquaAppCloudContentResponderInterface {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -56,7 +56,7 @@ class DebugResponderAsync extends EloquaAppCloudContentResponderBase implements 
   /**
    * {@inheritdoc}
    */
-  public function execute($instanceId, $record) {
+  public function execute($instanceId, $record, $query = NULL) {
     $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *  requiresConfiguration = "false",
+ *  requiresConfiguration = FALSE,
  *  height = "",
  *  width = "",
  *  editorImageUrl = ""

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  description = "Simple asynchronous content debugging tool that always returns the same HTML for every record",
  *  respond = "asynchronous",
  *  api = "contacts",
- *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -3,6 +3,7 @@
 namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponder;
 
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderInterface;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -11,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudContentResponder(
  *  id = "ContentDebugResponderAsync",
  *  label = @Translation("Asynchronous Content Debug Responder"),
+ *  description = "Simple asynchronous content debugging tool that always returns the same HTML for every record",
  *  respond = "asynchronous",
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
@@ -19,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponderAsync extends EloquaAppCloudContentResponderBase {
+class DebugResponderAsync extends EloquaAppCloudContentResponderBase implements EloquaAppCloudContentResponderInterface {
 
   /**
    * @var LoggerInterface

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @EloquaAppCloudContentResponder(
- *  id = "ContentDebugResponder",
+ *  id = "ContentDebugResponderAsync",
  *  label = @Translation("Asynchronous Content Debug Responder"),
  *  respond = "asynchronous",
  *  api = "contacts",
@@ -54,6 +54,7 @@ class DebugResponderAsync extends EloquaAppCloudContentResponderBase {
     $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);
-    return "<div>DEBUG CONTENT</div>";
+    $record->content = "<div>DEBUG CONTENT</div>";
+    return $record;
   }
 }

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -18,7 +18,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
- *   }
+ *   },
+ *   requiresConfiguration = "false",
+ *   height = "",
+ *   width = "",
+ *   editorImageUrl = ""
  * )
  */
 class DebugResponderAsync extends EloquaAppCloudContentResponderBase implements EloquaAppCloudContentResponderInterface {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -56,7 +56,7 @@ class DebugResponderAsync extends EloquaAppCloudContentResponderBase implements 
   /**
    * {@inheritdoc}
    */
-  public function execute($record) {
+  public function execute($instanceId, $record) {
     $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudContentResponder(
  *  id = "ContentDebugResponder",
  *  label = @Translation("Asynchronous Content Debug Responder"),
- *  respond = 'asynchronous',
+ *  respond = "'"asynchronous",
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderAsync.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudContentResponder(
  *  id = "ContentDebugResponder",
  *  label = @Translation("Asynchronous Content Debug Responder"),
- *  respond = "'"asynchronous",
+ *  respond = "asynchronous",
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -56,7 +56,7 @@ class DebugResponderSync extends EloquaAppCloudContentResponderBase implements E
   /**
    * {@inheritdoc}
    */
-  public function execute($instanceId, $record) {
+  public function execute($instanceId, $record, $query = NULL) {
     $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -56,7 +56,7 @@ class DebugResponderSync extends EloquaAppCloudContentResponderBase implements E
   /**
    * {@inheritdoc}
    */
-  public function execute($record) {
+  public function execute($instanceId, $record) {
     $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -11,7 +11,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudContentResponder(
  *  id = "ContentDebugResponder",
  *  label = @Translation("Synchronous Content Debug Responder"),
- *  respond = 'synchronous',
+ *  respond = "synchronous",
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *  requiresConfiguration = "false",
+ *  requiresConfiguration = FALSE,
  *  height = "",
  *  width = "",
  *  editorImageUrl = ""

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -18,7 +18,11 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
- *   }
+ *   },
+ *   requiresConfiguration = "false",
+ *   height = "",
+ *   width = "",
+ *   editorImageUrl = ""
  * )
  */
 class DebugResponderSync extends EloquaAppCloudContentResponderBase implements EloquaAppCloudContentResponderInterface {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -3,6 +3,7 @@
 namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponder;
 
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderInterface;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -11,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudContentResponder(
  *  id = "ContentDebugResponderSync",
  *  label = @Translation("Synchronous Content Debug Responder"),
+ *  description = "Simple synchronous content debugging tool that always returns the same HTML for every record",
  *  respond = "synchronous",
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_content_queue_worker",
@@ -19,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponderSync extends EloquaAppCloudContentResponderBase {
+class DebugResponderSync extends EloquaAppCloudContentResponderBase implements EloquaAppCloudContentResponderInterface {
 
   /**
    * @var LoggerInterface
@@ -56,6 +58,6 @@ class DebugResponderSync extends EloquaAppCloudContentResponderBase {
     ]);
 
     // For a synchronous result (only content?) just return HTML.
-    return "<div>DEBUG CONTENT</div>";
+    return "<div>Synchronous DEBUG CONTENT</div>";
   }
 }

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -1,24 +1,25 @@
 <?php
 
-namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponder;
+namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponder;
 
-use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderBase;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @EloquaAppCloudDecisionResponder(
- *  id = "DecisionDebugResponderYes",
- *  label = @Translation("Decision Debug Responder (yes)"),
+ * @EloquaAppCloudContentResponder(
+ *  id = "ContentDebugResponder",
+ *  label = @Translation("Synchronous Content Debug Responder"),
+ *  respond = 'synchronous',
  *  api = "contacts",
- *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
+ *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   }
  * )
  */
-class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
+class DebugResponderSync extends EloquaAppCloudContentResponderBase {
 
   /**
    * @var LoggerInterface
@@ -50,10 +51,11 @@ class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
    * {@inheritdoc}
    */
   public function execute($record) {
-    $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is YES', [
+    $this->logger->debug('Received content service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);
-    $record->result = TRUE;
-    return $record;
+
+    // For a synchronous result (only content?) just return HTML.
+    return "<div>DEBUG CONTENT</div>";
   }
 }

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -19,10 +19,10 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *   requiresConfiguration = "false",
- *   height = "",
- *   width = "",
- *   editorImageUrl = ""
+ *  requiresConfiguration = "false",
+ *  height = "",
+ *  width = "",
+ *  editorImageUrl = ""
  * )
  */
 class DebugResponderSync extends EloquaAppCloudContentResponderBase implements EloquaAppCloudContentResponderInterface {

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @EloquaAppCloudContentResponder(
- *  id = "ContentDebugResponder",
+ *  id = "ContentDebugResponderSync",
  *  label = @Translation("Synchronous Content Debug Responder"),
  *  respond = "synchronous",
  *  api = "contacts",

--- a/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
+++ b/src/Plugin/EloquaAppCloudContentResponder/DebugResponderSync.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  description = "Simple synchronous content debugging tool that always returns the same HTML for every record",
  *  respond = "synchronous",
  *  api = "contacts",
- *  queueWorker = "eloqua_app_cloud_content_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -9,7 +9,7 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
 
-  public function instantiate($instanceId){
+  public function instantiate($instanceId, $query = NULL){
     $response = new \stdClass();
     $response->recordDefinition = $this->fieldList();
     $response->height = $this->height();

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -8,4 +8,26 @@ namespace Drupal\eloqua_app_cloud\Plugin;
  */
 abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function height() {
+    // Retrieve the @height property from the annotation and return it.
+    return (string) $this->pluginDefinition['height'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function width() {
+    // Retrieve the @width property from the annotation and return it.
+    return (string) $this->pluginDefinition['width'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function editorImageUrl() {
+    // Retrieve the @editorImageUrl property from the annotation and return it.
+    return (string) $this->pluginDefinition['editorImageUrl'];
+  }
 }

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+/**
+ * Base class for Eloqua AppCloud Content Responder plugins.
+ */
+abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudContentResponderInterface {
+
+  // Add common methods and abstract methods for your plugin type here.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function api() {
+    // Retrieve the @api property from the annotation and return it.
+    return (string) $this->pluginDefinition['api'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function fieldList() {
+    // Retrieve the @fieldList property from the annotation and return it.
+    return (array) $this->pluginDefinition['fieldList'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function queueWorker() {
+    // Retrieve the @queueWorker property from the annotation and return it.
+    return (string) $this->pluginDefinition['queueWorker'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function respond() {
+    // Retrieve the @respond property from the annotation and return it.
+    return (string) $this->pluginDefinition['respond'];
+  }
+
+}

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -4,39 +4,8 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 
 /**
  * Base class for Eloqua AppCloud Content Responder plugins.
+ *
  */
-abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudContentResponderInterface {
-
+abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
-
-  /**
-   * {@inheritdoc}
-   */
-  public function api() {
-    // Retrieve the @api property from the annotation and return it.
-    return (string) $this->pluginDefinition['api'];
-  }
-  /**
-   * {@inheritdoc}
-   */
-  public function fieldList() {
-    // Retrieve the @fieldList property from the annotation and return it.
-    return (array) $this->pluginDefinition['fieldList'];
-  }
-  /**
-   * {@inheritdoc}
-   */
-  public function queueWorker() {
-    // Retrieve the @queueWorker property from the annotation and return it.
-    return (string) $this->pluginDefinition['queueWorker'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function respond() {
-    // Retrieve the @respond property from the annotation and return it.
-    return (string) $this->pluginDefinition['respond'];
-  }
-
 }

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -20,12 +20,11 @@ abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteract
    * @return \stdClass
    */
   public function instantiate($instanceId, $query = NULL){
-    $response = new \stdClass();
-    $response->recordDefinition = $this->fieldList();
+    $response = parent::instantiate($instanceId, $query);
+
     $response->height = $this->height();
     $response->width = $this->width();
     $response->editorImageUrl = $this->editorImageUrl();
-    $response->requiresConfiguration = $this->requiresConfiguration();
     return $response;
   }
 

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -31,6 +31,14 @@ abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteract
   /**
    * {@inheritdoc}
    */
+  public function queueWorker() {
+    // Return a valid queueWorker for this plugin class.
+    return "eloqua_app_cloud_content_queue_worker";
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function height() {
     // Retrieve the @height property from the annotation and return it.
     return (string) $this->pluginDefinition['height'];

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -9,7 +9,7 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
 
-  public function instantiate(){
+  public function instantiate($instanceId){
     $response = new \stdClass();
     $response->recordDefinition = $this->fieldList();
     $response->height = $this->height();

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -7,8 +7,6 @@ namespace Drupal\eloqua_app_cloud\Plugin;
  *
  */
 abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
-  // Add common methods and abstract methods for your plugin type here.
-
 
   /**
    * Unlike many of the other instantiations the content plugins send back some additional

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -9,6 +9,16 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
 
+  public function instantiate(){
+    $response = new \stdClass();
+    $response->recordDefinition = $this->fieldList();
+    $response->height = $this->height();
+    $response->width = $this->width();
+    $response->editorImageUrl = $this->editorImageUrl();
+    $response->requiresConfiguration = $this->requiresConfiguration();
+    return $response;
+  }
+
   /**
    * {@inheritdoc}
    */

--- a/src/Plugin/EloquaAppCloudContentResponderBase.php
+++ b/src/Plugin/EloquaAppCloudContentResponderBase.php
@@ -9,6 +9,18 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 abstract class EloquaAppCloudContentResponderBase extends EloquaAppCloudInteractiveResponderBase {
   // Add common methods and abstract methods for your plugin type here.
 
+
+  /**
+   * Unlike many of the other instantiations the content plugins send back some additional
+   * information that Eloqua uses as layout instructions for their UI.
+   * Height, Width, and editorImageUrl control what Eloqua shows in a "rendered" html email
+   * or landing page preview.
+   *
+   * @param $instanceId
+   * @param null $query
+   *
+   * @return \stdClass
+   */
   public function instantiate($instanceId, $query = NULL){
     $response = new \stdClass();
     $response->recordDefinition = $this->fieldList();

--- a/src/Plugin/EloquaAppCloudContentResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudContentResponderInterface.php
@@ -14,19 +14,19 @@ interface EloquaAppCloudContentResponderInterface extends EloquaAppCloudInteract
 
   /**
    * @return string
-   *     The height to render the content.
+   *  The height to render the content.
    */
   public function height();
 
   /**
    * @return string
-   *     The width to render the content.
+   *  The width to render the content.
    */
   public function width();
 
   /**
    * @return string
-   *     The absolute URL to an image which will be displayed when an editor inserts this content in an email.
+   *  The absolute URL to an image which will be displayed when an editor inserts this content in an email.
    */
   public function editorImageUrl();
 

--- a/src/Plugin/EloquaAppCloudContentResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudContentResponderInterface.php
@@ -6,6 +6,28 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 
 /**
  * Defines an interface for Eloqua AppCloud Content Responder plugins.
+ * The height and width parameters define the size of the content instance when rendered, while
+ * editorImageUrl specifies the URL for an image that Eloqua will display in the
+ * editor's design surface.
  */
 interface EloquaAppCloudContentResponderInterface extends EloquaAppCloudInteractiveResponderInterface {
+
+  /**
+   * @return string
+   *     The height to render the content.
+   */
+  public function height();
+
+  /**
+   * @return string
+   *     The width to render the content.
+   */
+  public function width();
+
+  /**
+   * @return string
+   *     The absolute URL to an image which will be displayed when an editor inserts this content in an email.
+   */
+  public function editorImageUrl();
+
 }

--- a/src/Plugin/EloquaAppCloudContentResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudContentResponderInterface.php
@@ -7,40 +7,5 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 /**
  * Defines an interface for Eloqua AppCloud Content Responder plugins.
  */
-interface EloquaAppCloudContentResponderInterface extends PluginInspectionInterface {
-
-  /**
-   * Method that gets executed when a Content Service is invoked from within the
-   * Eloqua UI.
-   *
-   * @param object $record
-   * object jsondecoded from Eloqua transmission.
-   *
-   * @return null
-   */
-  public function execute($record);
-
-  /**
-   * @return array
-   *    The list of fields this plugin needs from Eloqua.
-   */
-  public function fieldList();
-  /**
-   * @return string
-   *    The API type (contacts or customObject)
-   */
-  public function api();
-
-  /**
-   * @return string
-   *     The name of the queue worker plugin this plugin requires.
-   */
-  public function queueWorker();
-
-  /**
-   * @return string
-   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
-   */
-  public function respond();
-
+interface EloquaAppCloudContentResponderInterface extends EloquaAppCloudInteractiveResponderInterface {
 }

--- a/src/Plugin/EloquaAppCloudContentResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudContentResponderInterface.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Eloqua AppCloud Content Responder plugins.
+ */
+interface EloquaAppCloudContentResponderInterface extends PluginInspectionInterface {
+
+  /**
+   * Method that gets executed when a Content Service is invoked from within the
+   * Eloqua UI.
+   *
+   * @param object $record
+   * object jsondecoded from Eloqua transmission.
+   *
+   * @return null
+   */
+  public function execute($record);
+
+  /**
+   * @return array
+   *    The list of fields this plugin needs from Eloqua.
+   */
+  public function fieldList();
+  /**
+   * @return string
+   *    The API type (contacts or customObject)
+   */
+  public function api();
+
+  /**
+   * @return string
+   *     The name of the queue worker plugin this plugin requires.
+   */
+  public function queueWorker();
+
+  /**
+   * @return string
+   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
+   */
+  public function respond();
+
+}

--- a/src/Plugin/EloquaAppCloudContentResponderManager.php
+++ b/src/Plugin/EloquaAppCloudContentResponderManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides the Eloqua AppCloud Content Responder plugin manager.
+ */
+class EloquaAppCloudContentResponderManager extends DefaultPluginManager {
+
+  /**
+   * Constructor for EloquaAppCloudContentResponderManager objects.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/EloquaAppCloudContentResponder', $namespaces, $module_handler, 'Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudContentResponderInterface', 'Drupal\eloqua_app_cloud\Annotation\EloquaAppCloudContentResponder');
+
+    $this->alterInfo('eloqua_app_cloud_eloqua_app_cloud_content_responder_info');
+    $this->setCacheBackend($cache_backend, 'eloqua_app_cloud_eloqua_app_cloud_content_responder_plugins');
+  }
+
+}

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponder.php
@@ -50,14 +50,10 @@ class DebugResponder extends EloquaAppCloudDecisionResponderBase {
    * {@inheritdoc}
    */
   public function execute($record) {
-    $this->logger->debug('Received decision service hook with payload @record', [
+    $this->logger->debug('Plugin says - received decision service hook with payload @record', [
       '@record' => print_r($record, TRUE),
     ]);
-    if($record->EmailAddress == "jkopel@tableau.com"){
-      $record->result = FALSE;
-    }else {
-      $record->result = TRUE;
-    }
+    $record->result = TRUE;
     return $record;
   }
 

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponder.php
@@ -1,19 +1,24 @@
 <?php
 
-namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudFirehoseResponder;
+namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponder;
 
-use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudFirehoseResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderBase;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
- * @EloquaAppCloudFirehoseResponder(
- *  id = "FirehoseDebugResponder",
- *  label = @Translation("Debug Responder"),
+ * @EloquaAppCloudDecisionResponder(
+ *  id = "DecisionDebugResponder",
+ *  label = @Translation("Decision Debug Responder"),
+ *  api = "contacts",
+ *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
+ *  fieldList = {
+ *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
+ *   }
  * )
  */
-class DebugResponder extends EloquaAppCloudFirehoseResponderBase {
+class DebugResponder extends EloquaAppCloudDecisionResponderBase {
 
   /**
    * @var LoggerInterface
@@ -44,17 +49,14 @@ class DebugResponder extends EloquaAppCloudFirehoseResponderBase {
   /**
    * {@inheritdoc}
    */
-  public function execute(array &$render, array $params) {
-    $this->logger->debug('Received firehose service hook with params @params', [
-      '@params' => print_r($params, TRUE),
+  public function execute($record) {
+    $this->logger->debug('Received decision service hook with payload @record', [
+      '@record' => print_r($record, TRUE),
     ]);
-  }
+    if($record->EmailAddress == "jkopel@tableau.com"){
+      return FALSE;
+    }
 
-  /**
-   * {@inheritdoc}
-   */
-  public function getPluginId() {
-    return 'FirehoseDebugResponder';
+    return TRUE;
   }
-
 }

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *   requiresConfiguration = "false"
+ *  requiresConfiguration = "false"
  * )
  */
 class DebugResponderNo extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  description = "Simple decision debugging tool that always returns a NO for every record",
  *  api = "contacts",
  *  respond = "asynchronous",
- *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -3,6 +3,7 @@
 namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponder;
 
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderInterface;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -11,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudDecisionResponder(
  *  id = "DecisionDebugResponderNo",
  *  label = @Translation("Decision Debug Responder (no)"),
+ *  description = "Simple decision debugging tool that always returns a NO for every record",
  *  api = "contacts",
  *  respond = "asynchronous",
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
@@ -19,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponderNo extends EloquaAppCloudDecisionResponderBase {
+class DebugResponderNo extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {
 
   /**
    * @var LoggerInterface

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -53,7 +53,7 @@ class DebugResponderNo extends EloquaAppCloudDecisionResponderBase implements El
   /**
    * {@inheritdoc}
    */
-  public function execute($record) {
+  public function execute($instanceId, $record) {
     $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is NO', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -9,8 +9,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @EloquaAppCloudDecisionResponder(
- *  id = "DecisionDebugResponderYes",
- *  label = @Translation("Decision Debug Responder (yes)"),
+ *  id = "DecisionDebugResponderNo",
+ *  label = @Translation("Decision Debug Responder (no)"),
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
+class DebugResponderNo extends EloquaAppCloudDecisionResponderBase {
 
   /**
    * @var LoggerInterface
@@ -50,10 +50,10 @@ class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
    * {@inheritdoc}
    */
   public function execute($record) {
-    $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is YES', [
+    $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is NO', [
       '@record' => print_r($record, TRUE),
     ]);
-    $record->result = TRUE;
+    $record->result = FALSE;
     return $record;
   }
 

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -53,7 +53,7 @@ class DebugResponderNo extends EloquaAppCloudDecisionResponderBase implements El
   /**
    * {@inheritdoc}
    */
-  public function execute($instanceId, $record) {
+  public function execute($instanceId, $record, $query = NULL) {
     $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is NO', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  id = "DecisionDebugResponderNo",
  *  label = @Translation("Decision Debug Responder (no)"),
  *  api = "contacts",
+ *  respond = "asynchronous",
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *  requiresConfiguration = "false"
+ *  requiresConfiguration = FALSE
  * )
  */
 class DebugResponderNo extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderNo.php
@@ -18,7 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
- *   }
+ *   },
+ *   requiresConfiguration = "false"
  * )
  */
 class DebugResponderNo extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -52,7 +52,7 @@ class DebugResponderYes extends EloquaAppCloudDecisionResponderBase implements E
   /**
    * {@inheritdoc}
    */
-  public function execute($instanceId, $record) {
+  public function execute($instanceId, $record, $query = NULL) {
     $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is YES', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -12,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  id = "DecisionDebugResponderYes",
  *  label = @Translation("Decision Debug Responder (yes)"),
  *  api = "contacts",
+ *  respond = "asynchronous",
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -9,8 +9,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @EloquaAppCloudDecisionResponder(
- *  id = "DecisionDebugResponder",
- *  label = @Translation("Decision Debug Responder"),
+ *  id = "DecisionDebugResponderYes",
+ *  label = @Translation("Decision Debug Responder (yes)"),
  *  api = "contacts",
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponder extends EloquaAppCloudDecisionResponderBase {
+class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
 
   /**
    * @var LoggerInterface

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -18,7 +18,8 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
- *   },requiresConfiguration = "false"
+ *   },
+ *  requiresConfiguration = "false"
  * )
  */
 class DebugResponderYes extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -18,7 +18,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
- *   }
+ *   },requiresConfiguration = "false"
  * )
  */
 class DebugResponderYes extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -52,7 +52,7 @@ class DebugResponderYes extends EloquaAppCloudDecisionResponderBase implements E
   /**
    * {@inheritdoc}
    */
-  public function execute($record) {
+  public function execute($instanceId, $record) {
     $this->logger->debug('Plugin says - received decision service hook with payload @record. Our decision is YES', [
       '@record' => print_r($record, TRUE),
     ]);

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -15,7 +15,6 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  description = "Simple decision debugging tool that always returns a YES for every record",
  *  api = "contacts",
  *  respond = "asynchronous",
- *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -19,7 +19,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *  fieldList = {
  *    "EmailAddress" = "{{Contact.Field(C_EmailAddress)}}"
  *   },
- *  requiresConfiguration = "false"
+ *  requiresConfiguration = FALSE
  * )
  */
 class DebugResponderYes extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {

--- a/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponder/DebugResponderYes.php
@@ -3,6 +3,7 @@
 namespace Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponder;
 
 use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderBase;
+use Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderInterface;
 use Drupal\eloqua_rest_api\Factory\ClientFactory;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -11,6 +12,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  * @EloquaAppCloudDecisionResponder(
  *  id = "DecisionDebugResponderYes",
  *  label = @Translation("Decision Debug Responder (yes)"),
+ *  description = "Simple decision debugging tool that always returns a YES for every record",
  *  api = "contacts",
  *  respond = "asynchronous",
  *  queueWorker = "eloqua_app_cloud_decision_queue_worker",
@@ -19,7 +21,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
  *   }
  * )
  */
-class DebugResponderYes extends EloquaAppCloudDecisionResponderBase {
+class DebugResponderYes extends EloquaAppCloudDecisionResponderBase implements EloquaAppCloudDecisionResponderInterface {
 
   /**
    * @var LoggerInterface

--- a/src/Plugin/EloquaAppCloudDecisionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderBase.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+/**
+ * Base class for Eloqua AppCloud Decision Responder plugins.
+ */
+abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudDecisionResponderInterface {
+
+  // Add common methods and abstract methods for your plugin type here.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function api() {
+    // Retrieve the @api property from the annotation and return it.
+    return (string) $this->pluginDefinition['api'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function fieldList() {
+    // Retrieve the @fieldList property from the annotation and return it.
+    return (array) $this->pluginDefinition['fieldList'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function queueWorker() {
+    // Retrieve the @queueWorker property from the annotation and return it.
+    return (string) $this->pluginDefinition['queueWorker'];
+  }
+}

--- a/src/Plugin/EloquaAppCloudDecisionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderBase.php
@@ -5,37 +5,6 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 /**
  * Base class for Eloqua AppCloud Decision Responder plugins.
  */
-abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudDecisionResponderInterface {
-
+abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudInteractiveResponderBase  {
   // Add common methods and abstract methods for your plugin type here.
-
-  /**
-   * {@inheritdoc}
-   */
-  public function api() {
-    // Retrieve the @api property from the annotation and return it.
-    return (string) $this->pluginDefinition['api'];
-  }
-  /**
-   * {@inheritdoc}
-   */
-  public function fieldList() {
-    // Retrieve the @fieldList property from the annotation and return it.
-    return (array) $this->pluginDefinition['fieldList'];
-  }
-  /**
-   * {@inheritdoc}
-   */
-  public function queueWorker() {
-    // Retrieve the @queueWorker property from the annotation and return it.
-    return (string) $this->pluginDefinition['queueWorker'];
-  }
-
-  /**
-   * {@inheritdoc}
-   */
-  public function respond() {
-    // Retrieve the @respond property from the annotation and return it.
-    return (string) $this->pluginDefinition['respond'];
-  }
 }

--- a/src/Plugin/EloquaAppCloudDecisionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderBase.php
@@ -30,4 +30,12 @@ abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudRespond
     // Retrieve the @queueWorker property from the annotation and return it.
     return (string) $this->pluginDefinition['queueWorker'];
   }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function respond() {
+    // Retrieve the @respond property from the annotation and return it.
+    return (string) $this->pluginDefinition['respond'];
+  }
 }

--- a/src/Plugin/EloquaAppCloudDecisionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderBase.php
@@ -5,7 +5,7 @@ namespace Drupal\eloqua_app_cloud\Plugin;
 /**
  * Base class for Eloqua AppCloud Decision Responder plugins.
  */
-abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudInteractiveResponderBase  {
+abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudInteractiveResponderBase {
 
   /**
    * {@inheritdoc}
@@ -13,4 +13,5 @@ abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudInterac
   public function queueWorker() {
     // Return a valid queueWorker for this plugin class.
     return "eloqua_app_cloud_decision_queue_worker";
-  }}
+  }
+}

--- a/src/Plugin/EloquaAppCloudDecisionResponderBase.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderBase.php
@@ -6,5 +6,11 @@ namespace Drupal\eloqua_app_cloud\Plugin;
  * Base class for Eloqua AppCloud Decision Responder plugins.
  */
 abstract class EloquaAppCloudDecisionResponderBase extends EloquaAppCloudInteractiveResponderBase  {
-  // Add common methods and abstract methods for your plugin type here.
-}
+
+  /**
+   * {@inheritdoc}
+   */
+  public function queueWorker() {
+    // Return a valid queueWorker for this plugin class.
+    return "eloqua_app_cloud_decision_queue_worker";
+  }}

--- a/src/Plugin/EloquaAppCloudDecisionResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderInterface.php
@@ -37,4 +37,10 @@ interface EloquaAppCloudDecisionResponderInterface extends PluginInspectionInter
    */
   public function queueWorker();
 
+  /**
+   * @return string
+   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
+   */
+  public function respond();
+
 }

--- a/src/Plugin/EloquaAppCloudDecisionResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderInterface.php
@@ -7,40 +7,5 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
 /**
  * Defines an interface for Eloqua AppCloud Decision Responder plugins.
  */
-interface EloquaAppCloudDecisionResponderInterface extends PluginInspectionInterface {
-
-  /**
-   * Method that gets executed when a Decision Service is invoked from within the
-   * Eloqua UI.
-   *
-   * @param object $record
-   * object jsondecoded from Eloqua transmission.
-   *
-   * @return null
-   */
-  public function execute($record);
-
-  /**
-   * @return array
-   *    The list of fields this plugin needs from Eloqua.
-   */
-  public function fieldList();
-  /**
-   * @return string
-   *    The API type (contacts or customObject)
-   */
-  public function api();
-
-  /**
-   * @return string
-   *     The name of the queue worker plugin this plugin requires.
-   */
-  public function queueWorker();
-
-  /**
-   * @return string
-   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
-   */
-  public function respond();
-
+interface EloquaAppCloudDecisionResponderInterface extends EloquaAppCloudInteractiveResponderInterface {
 }

--- a/src/Plugin/EloquaAppCloudDecisionResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Eloqua AppCloud Decision Responder plugins.
+ */
+interface EloquaAppCloudDecisionResponderInterface extends PluginInspectionInterface {
+
+  /**
+   * Method that gets executed when a Decision Service is invoked from within the
+   * Eloqua UI.
+   *
+   * @param object $record
+   * object jsondecoded from Eloqua transmission.
+   *
+   * @return null
+   */
+  public function execute($record);
+
+  /**
+   * @return array
+   *    The list of fields this plugin needs from Eloqua.
+   */
+  public function fieldList();
+  /**
+   * @return string
+   *    The API type (contacts or customObject)
+   */
+  public function api();
+
+  /**
+   * @return string
+   *     The name of the queue worker plugin this plugin requires.
+   */
+  public function queueWorker();
+
+}

--- a/src/Plugin/EloquaAppCloudDecisionResponderManager.php
+++ b/src/Plugin/EloquaAppCloudDecisionResponderManager.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+
+/**
+ * Provides the Eloqua AppCloud Decision Responder plugin manager.
+ */
+class EloquaAppCloudDecisionResponderManager extends DefaultPluginManager {
+
+  /**
+   * Constructor for EloquaAppCloudDecisionResponderManager objects.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct('Plugin/EloquaAppCloudDecisionResponder', $namespaces, $module_handler, 'Drupal\eloqua_app_cloud\Plugin\EloquaAppCloudDecisionResponderInterface', 'Drupal\eloqua_app_cloud\Annotation\EloquaAppCloudDecisionResponder');
+
+    $this->alterInfo('eloqua_app_cloud_eloqua_app_cloud_decision_responder_info');
+    $this->setCacheBackend($cache_backend, 'eloqua_app_cloud_eloqua_app_cloud_decision_responder_plugins');
+  }
+
+}

--- a/src/Plugin/EloquaAppCloudFirehoseResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudFirehoseResponder/DebugResponder.php
@@ -56,5 +56,4 @@ class DebugResponder extends EloquaAppCloudFirehoseResponderBase {
   public function getPluginId() {
     return 'FirehoseDebugResponder';
   }
-
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -26,6 +26,14 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   }
 
   /**
+   * Handle any task required to cleanly delete this plugin.
+   * @param $instanceID
+   */
+  public function delete($instanceID){
+
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function api() {

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -10,6 +10,14 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
 
   // Add common methods and abstract methods for your plugin type here.
 
+
+  public function instantiate(){
+    $response = new \stdClass();
+    $response->recordDefinition = $this->fieldList();
+    $response->requiresConfiguration = $this->requiresConfiguration();
+    return $response;
+  }
+
   /**
    * Return a default string that gets rendered in the Eloqua canvas interface. This should be overridden in plugin to return a form if the plugin is configurable.
    */
@@ -50,6 +58,14 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   /**
    * {@inheritdoc}
    */
+  public function label() {
+    // Retrieve the @description property from the annotation and return it.
+    return (string) $this->pluginDefinition['label'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
   public function description() {
     // Retrieve the @label property from the annotation and return it.
     return (string) $this->pluginDefinition['description'];
@@ -58,9 +74,9 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   /**
    * {@inheritdoc}
    */
-  public function label() {
-    // Retrieve the @description property from the annotation and return it.
-    return (string) $this->pluginDefinition['label'];
+  public function requiresConfiguration() {
+    // Retrieve the @requiresConfiguration property from the annotation and return it.
+    return (string) $this->pluginDefinition['requiresConfiguration'];
   }
 
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -95,8 +95,9 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * {@inheritdoc}
    */
   public function requiresConfiguration() {
-    // Retrieve the @requiresConfiguration property from the annotation and return it.
-    return (string) $this->pluginDefinition['requiresConfiguration'];
+    // Retrieve the @requiresConfiguration property from the annotation and return the appropriate string
+    // version for Eloqua.
+    return $this->pluginDefinition['requiresConfiguration'] ? "yes" : "no";
   }
 
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -11,7 +11,13 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   // Add common methods and abstract methods for your plugin type here.
 
 
-  public function instantiate($instanceId){
+  /**
+   * @param $instanceId
+   * @param $query
+   *
+   * @return \stdClass
+   */
+  public function instantiate($instanceId, $query = NULL){
     $response = new \stdClass();
     $response->recordDefinition = $this->fieldList();
     $response->requiresConfiguration = $this->requiresConfiguration();
@@ -20,16 +26,22 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
 
   /**
    * Return a default string that gets rendered in the Eloqua canvas interface. This should be overridden in plugin to return a form if the plugin is configurable.
+   *
+   * @param $instanceId
+   * @param $query
+   *
+   * @return mixed|string
    */
-  public function update($instanceId){
+  public function update($instanceId, $query = NULL){
     return (string) $this->pluginDefinition['description'];
   }
 
   /**
    * Handle any task required to cleanly delete this plugin.
    * @param $instanceID
+   * @param $query
    */
-  public function delete($instanceID){
+  public function delete($instanceID, $query = NULL){
 
   }
 

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+/**
+ * Base class for Eloqua AppCloud Interactive Responder plugins.
+ *
+ */
+abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResponderBase implements EloquaAppCloudInteractiveResponderInterface {
+
+  // Add common methods and abstract methods for your plugin type here.
+
+  /**
+   * {@inheritdoc}
+   */
+  public function api() {
+    // Retrieve the @api property from the annotation and return it.
+    return (string) $this->pluginDefinition['api'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function fieldList() {
+    // Retrieve the @fieldList property from the annotation and return it.
+    return (array) $this->pluginDefinition['fieldList'];
+  }
+  /**
+   * {@inheritdoc}
+   */
+  public function queueWorker() {
+    // Retrieve the @queueWorker property from the annotation and return it.
+    return (string) $this->pluginDefinition['queueWorker'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function respond() {
+    // Retrieve the @respond property from the annotation and return it.
+    return (string) $this->pluginDefinition['respond'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function description() {
+    // Retrieve the @description property from the annotation and return it.
+    return (string) $this->pluginDefinition['description'];
+  }
+
+}

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -88,7 +88,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * {@inheritdoc}
    */
   public function requiresConfiguration() {
-    return $this->pluginDefinition['requiresConfiguration'] ? "yes" : "no";
+    return (string) $this->pluginDefinition['requiresConfiguration'] ? "yes" : "no";
   }
 
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -18,6 +18,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * @return \stdClass
    */
   public function instantiate($instanceId, $query = NULL){
+
     $response = new \stdClass();
     $response->recordDefinition = $this->fieldList();
     $response->requiresConfiguration = $this->requiresConfiguration();
@@ -88,7 +89,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * {@inheritdoc}
    */
   public function requiresConfiguration() {
-    return (string) $this->pluginDefinition['requiresConfiguration'] ? "yes" : "no";
+    return (string) $this->pluginDefinition['requiresConfiguration'] ? "true" : "false";
   }
 
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -32,7 +32,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    *
    * @return mixed|string
    */
-  public function update($instanceId, $query = NULL){
+  public function update($instanceId, $query = NULL) {
     return (string) $this->pluginDefinition['description'];
   }
 
@@ -41,7 +41,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * @param $instanceID
    * @param $query
    */
-  public function delete($instanceID, $query = NULL){
+  public function delete($instanceID, $query = NULL) {
 
   }
 

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -11,7 +11,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   // Add common methods and abstract methods for your plugin type here.
 
 
-  public function instantiate(){
+  public function instantiate($instanceId){
     $response = new \stdClass();
     $response->recordDefinition = $this->fieldList();
     $response->requiresConfiguration = $this->requiresConfiguration();
@@ -21,7 +21,7 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   /**
    * Return a default string that gets rendered in the Eloqua canvas interface. This should be overridden in plugin to return a form if the plugin is configurable.
    */
-  public function update(){
+  public function update($instanceId){
     return (string) $this->pluginDefinition['description'];
   }
 

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -11,6 +11,13 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
   // Add common methods and abstract methods for your plugin type here.
 
   /**
+   * Return a default string that gets rendered in the Eloqua canvas interface. This should be overridden in plugin to return a form if the plugin is configurable.
+   */
+  public function update(){
+    return (string) $this->pluginDefinition['description'];
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function api() {
@@ -44,8 +51,16 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * {@inheritdoc}
    */
   public function description() {
-    // Retrieve the @description property from the annotation and return it.
+    // Retrieve the @label property from the annotation and return it.
     return (string) $this->pluginDefinition['description'];
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+    // Retrieve the @description property from the annotation and return it.
+    return (string) $this->pluginDefinition['label'];
   }
 
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderBase.php
@@ -59,13 +59,6 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
     // Retrieve the @fieldList property from the annotation and return it.
     return (array) $this->pluginDefinition['fieldList'];
   }
-  /**
-   * {@inheritdoc}
-   */
-  public function queueWorker() {
-    // Retrieve the @queueWorker property from the annotation and return it.
-    return (string) $this->pluginDefinition['queueWorker'];
-  }
 
   /**
    * {@inheritdoc}
@@ -95,8 +88,6 @@ abstract class EloquaAppCloudInteractiveResponderBase extends EloquaAppCloudResp
    * {@inheritdoc}
    */
   public function requiresConfiguration() {
-    // Retrieve the @requiresConfiguration property from the annotation and return the appropriate string
-    // version for Eloqua.
     return $this->pluginDefinition['requiresConfiguration'] ? "yes" : "no";
   }
 

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -101,8 +101,10 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
 
   /**
    * @return string
-   * Really a boolean flag but defined as a string since Eloqua seems to need
-   *   lowercase "true" and "false".
+   *
+   * If true than Eloqua will require a call to the update endpoint, and the response must indicate
+   * requiresConfiguration = FALSE before a canvas can be activated. The annotation defines a boolean, but this
+   * function needs to return a string in the format "yes" or "no"
    */
   public function requiresConfiguration();
 

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -9,9 +9,24 @@ use Drupal\Component\Plugin\PluginInspectionInterface;
  */
 interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionInterface {
 
+
   /**
-   * Method that gets executed when a Interactive Service is invoked from within the
-   * Eloqua UI.
+   * Method gets called when a create call is sent by Eloqua.
+   *
+   * @return mixed
+   */
+  public function instantiate();
+
+  /**
+   * Method gets called when a configure (update) call is sent by Eloqua.
+   *
+   * @return mixed
+   */
+  public function update();
+
+  /**
+   * Method that gets executed when a Interactive Service is invoked from
+   * within the Eloqua UI.
    *
    * @param object $record
    * object jsondecoded from Eloqua transmission.
@@ -21,16 +36,11 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
   public function execute($record);
 
   /**
-   * Method gets called when a configure (update) call is sent by Eloqua.
-   * @return mixed
-   */
-  public function update();
-
-  /**
    * @return array
    *    The list of fields this plugin needs from Eloqua.
    */
   public function fieldList();
+
   /**
    * @return string
    *    The API type (contacts or customObject)
@@ -45,20 +55,30 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
 
   /**
    * @return string
-   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
+   *     The type of response this plugin requires (i.e. synchronous or
+   *   asynchronous).
    */
   public function respond();
 
   /**
    * @return string
-   *     The label of this plugin. Will be used as page title for configure calls from Eloqua
+   *     The label of this plugin. Will be used as page title for configure
+   *   calls from Eloqua
    */
   public function label();
 
   /**
    * @return string
-   *     The description of this plugin. Will be used for configure calls from Eloqua
+   *     The description of this plugin. Will be used for configure calls from
+   *   Eloqua
    */
   public function description();
+
+  /**
+   * @return string
+   * Really a boolean flag but defined as a string since Eloqua seems to need
+   *   lowercase "true" and "false".
+   */
+  public function requiresConfiguration();
 
 }

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -29,6 +29,14 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
   public function update($instanceId);
 
   /**
+   * Method gets called by nightly delete batch from Eloqua.
+   * @param $instanceId
+   *
+   * @return mixed
+   */
+  public function delete($instanceId);
+
+  /**
    * Method that gets executed when a Interactive Service is invoked from
    * within the Eloqua UI.
    *

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+
+/**
+ * Defines an interface for Eloqua AppCloud Interactive Responder plugins.
+ */
+interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionInterface {
+
+  /**
+   * Method that gets executed when a Interactive Service is invoked from within the
+   * Eloqua UI.
+   *
+   * @param object $record
+   * object jsondecoded from Eloqua transmission.
+   *
+   * @return null
+   */
+  public function execute($record);
+
+  /**
+   * @return array
+   *    The list of fields this plugin needs from Eloqua.
+   */
+  public function fieldList();
+  /**
+   * @return string
+   *    The API type (contacts or customObject)
+   */
+  public function api();
+
+  /**
+   * @return string
+   *     The name of the queue worker plugin this plugin requires.
+   */
+  public function queueWorker();
+
+  /**
+   * @return string
+   *     The type of response this plugin requires (i.e. synchronous or asynchronous).
+   */
+  public function respond();
+
+  /**
+   * @return string
+   *     The description of this plugin. Will be used for configure calls from Eloqua
+   */
+  public function description();
+
+}

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -21,6 +21,12 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
   public function execute($record);
 
   /**
+   * Method gets called when a configure (update) call is sent by Eloqua.
+   * @return mixed
+   */
+  public function update();
+
+  /**
    * @return array
    *    The list of fields this plugin needs from Eloqua.
    */
@@ -42,6 +48,12 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
    *     The type of response this plugin requires (i.e. synchronous or asynchronous).
    */
   public function respond();
+
+  /**
+   * @return string
+   *     The label of this plugin. Will be used as page title for configure calls from Eloqua
+   */
+  public function label();
 
   /**
    * @return string

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -105,7 +105,7 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
    * If true than Eloqua will require a call to the update endpoint, and the response must indicate
    * requiresConfiguration = FALSE before a canvas can be activated.
    * The annotation defines a boolean, but this
-   * function needs to return a string in the format "yes" or "no"
+   * function needs to return a string in the format "true" or "false"
    */
   public function requiresConfiguration();
 

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -103,7 +103,8 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
    * @return string
    *
    * If true than Eloqua will require a call to the update endpoint, and the response must indicate
-   * requiresConfiguration = FALSE before a canvas can be activated. The annotation defines a boolean, but this
+   * requiresConfiguration = FALSE before a canvas can be activated.
+   * The annotation defines a boolean, but this
    * function needs to return a string in the format "yes" or "no"
    */
   public function requiresConfiguration();

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -13,27 +13,32 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
   /**
    * Method gets called when a create call is sent by Eloqua.
    *
+   * @param $instanceId
+   *
    * @return mixed
    */
-  public function instantiate();
+  public function instantiate($instanceId);
 
   /**
    * Method gets called when a configure (update) call is sent by Eloqua.
    *
+   * @param $instanceId
+   *
    * @return mixed
    */
-  public function update();
+  public function update($instanceId);
 
   /**
    * Method that gets executed when a Interactive Service is invoked from
    * within the Eloqua UI.
    *
+   * @param $instanceId
    * @param object $record
    * object jsondecoded from Eloqua transmission.
    *
    * @return null
    */
-  public function execute($record);
+  public function execute($instanceId, $record);
 
   /**
    * @return array

--- a/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
+++ b/src/Plugin/EloquaAppCloudInteractiveResponderInterface.php
@@ -15,26 +15,35 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
    *
    * @param $instanceId
    *
+   * @param $query
+   *
    * @return mixed
    */
-  public function instantiate($instanceId);
+  public function instantiate($instanceId, $query);
 
   /**
    * Method gets called when a configure (update) call is sent by Eloqua.
    *
    * @param $instanceId
    *
-   * @return mixed
-   */
-  public function update($instanceId);
-
-  /**
-   * Method gets called by nightly delete batch from Eloqua.
-   * @param $instanceId
+   * @param $query
+   *  The entire query string from whence to pluck additional values if available.
    *
    * @return mixed
    */
-  public function delete($instanceId);
+  public function update($instanceId, $query);
+
+  /**
+   * Method gets called by nightly delete batch from Eloqua.
+   *
+   * @param $instanceId
+   *
+   * @param $query
+   *  The entire query string from whence to pluck additional values if available.
+   *
+   * @return mixed
+   */
+  public function delete($instanceId, $query);
 
   /**
    * Method that gets executed when a Interactive Service is invoked from
@@ -44,9 +53,12 @@ interface EloquaAppCloudInteractiveResponderInterface extends PluginInspectionIn
    * @param object $record
    * object jsondecoded from Eloqua transmission.
    *
+   * @param $query
+   *   The entire query string from whence to pluck additional values if available.
+   *
    * @return null
    */
-  public function execute($instanceId, $record);
+  public function execute($instanceId, $record, $query);
 
   /**
    * @return array

--- a/src/Plugin/EloquaAppCloudMenuResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudMenuResponder/DebugResponder.php
@@ -85,5 +85,4 @@ class DebugResponder extends EloquaAppCloudMenuResponderBase {
   public function getPluginId() {
     return 'MenuDebugResponder';
   }
-
 }

--- a/src/Plugin/EloquaAppCloudMenuResponder/DebugResponder.php
+++ b/src/Plugin/EloquaAppCloudMenuResponder/DebugResponder.php
@@ -9,7 +9,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * @EloquaAppCloudMenuResponder(
- *  id = "DebugResponder",
+ *  id = "MenuDebugResponder",
  *  label = @Translation("Debug Responder"),
  * )
  */
@@ -83,7 +83,7 @@ class DebugResponder extends EloquaAppCloudMenuResponderBase {
    * {@inheritdoc}
    */
   public function getPluginId() {
-    return 'DebugResponder';
+    return 'MenuDebugResponder';
   }
 
 }

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -107,8 +107,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $client->authenticate(
       $clientConfig['eloqua_rest_api_site_name'],
       $clientConfig['eloqua_rest_api_login_name'],
-      $clientConfig['eloqua_rest_api_login_password'],
-      $clientConfig['eloqua_rest_api_base_url']
+      $clientConfig['eloqua_rest_api_login_password']
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eloqua_app_cloud\Plugin\QueueWorker;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Queue\QueueWorkerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -16,12 +17,12 @@ use Psr\Log\LoggerInterface;
  *
  * @property  logger
  * @QueueWorker(
- *  id = "eloqua_app_cloud_action_queue_worker",
- *  title = @Translation("The Eloqua AppCloud Queue worker for actions."),
+ *  id = "eloqua_app_cloud_decision_queue_worker",
+ *  title = @Translation("The Eloqua AppCloud Queue worker for decisions."),
  *  cron = {"time" = 60},
  * )
  */
-class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
    * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
@@ -34,6 +35,9 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
    * @var QueueFactory
    */
   protected $queueFactory;
+
+  /** @var  ConfigFactoryInterface */
+  protected $configFactory;
 
   /** @var  LoggerInterface */
   protected $logger;
@@ -49,10 +53,11 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
    *   The plugin implementation definition.
    */
   public function __construct(
-    array $configuration, $plugin_id, $plugin_definition, ClientFactory $eloqua_client_factory, QueueFactory $queueFactory, LoggerInterface $logger) {
+    array $configuration, $plugin_id, $plugin_definition, ClientFactory $eloqua_client_factory, QueueFactory $queueFactory, ConfigFactoryInterface $configFactory, LoggerInterface $logger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->eloquaClientFactory = $eloqua_client_factory;
     $this->queueFactory = $queueFactory;
+    $this->configFactory = $configFactory;
     $this->logger = $logger;
   }
 
@@ -66,6 +71,7 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
       $plugin_definition,
       $container->get('eloqua.client_factory'),
       $container->get('queue'),
+      $container->get('config.factory'),
       $container->get('logger.channel.eloqua_app_cloud')
     );
   }
@@ -95,7 +101,7 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
     $fieldList = $queueItem->fieldList;
     // Let's get a client so we can send our bulk API requests.
     $client = $this->eloquaClientFactory->get();
-    $clientConfig = \Drupal::config('eloqua_rest_api.settings')->get();
+    $clientConfig = $this->configFactory->get('eloqua_rest_api.settings');
     // Eloqua is sometimes very slow to respond -- be wary of timeouts.
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -17,12 +17,12 @@ use Psr\Log\LoggerInterface;
  *
  * @property  logger
  * @QueueWorker(
- *  id = "eloqua_app_cloud_decision_queue_worker",
- *  title = @Translation("The Eloqua AppCloud Queue worker for decisions."),
+ *  id = "eloqua_app_cloud_action_queue_worker",
+ *  title = @Translation("The Eloqua AppCloud Queue worker for actions."),
  *  cron = {"time" = 60},
  * )
  */
-class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
    * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
@@ -105,9 +105,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     // Eloqua is sometimes very slow to respond -- be wary of timeouts.
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(
-      $clientConfig['eloqua_rest_api_site_name'],
-      $clientConfig['eloqua_rest_api_login_name'],
-      $clientConfig['eloqua_rest_api_login_password']
+      $clientConfig->get('eloqua_rest_api_site_name'),
+      $clientConfig->get('eloqua_rest_api_login_name'),
+      $clientConfig->get('eloqua_rest_api_login_password')
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -106,10 +106,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(
       $clientConfig['eloqua_rest_api_site_name'],
-      // 'TableauSoftware',
       $clientConfig['eloqua_rest_api_login_name'],
       $clientConfig['eloqua_rest_api_login_password'],
-      'https://secure.p01.eloqua.com/API/Bulk'
+      $clientConfig['eloqua_rest_api_base_url']
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -35,7 +35,7 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
   protected $queueFactory;
 
   /**
-   * @var  ConfigFactoryInterface
+   * @var ConfigFactoryInterface
    */
   protected $configFactory;
 
@@ -121,8 +121,8 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
 
     // @TODO how to really handle custom objects.
     // If $cdo_id is set, push the Id to bulk process.
-    if (!empty($cdoId)) {
-      $bulkApi = $client->api($api)->bulk($cdoId);
+    if (!empty($queueItem->cdoId)) {
+      $bulkApi = $client->api($api)->bulk($queueItem->cdoId);
     }
     else {
       $bulkApi = $client->api($api)->bulk();

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -25,9 +25,7 @@ use Psr\Log\LoggerInterface;
 class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
-   * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
-   *
-   * @var \Drupal\eloqua_rest_api\Factory\ClientFactory
+   * @var ClientFactory
    */
   protected $eloquaClientFactory;
 
@@ -36,10 +34,14 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
    */
   protected $queueFactory;
 
-  /** @var  ConfigFactoryInterface */
+  /**
+   * @var  ConfigFactoryInterface
+   */
   protected $configFactory;
 
-  /** @var  LoggerInterface */
+  /**
+   * @var  LoggerInterface
+   */
   protected $logger;
 
   /**

--- a/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudActionQueueWorker.php
@@ -97,8 +97,7 @@ class EloquaAppCloudActionQueueWorker extends EloquaAppCloudQueueWorkerBase impl
 
     if (count($records)) {
       // Requeue the remainder.
-      /** @var QueueInterface $queue */
-      $queue = $this->queueFactory->get($queueItem->queueId);
+      $queue = $this->queueFactory->get($queueItem->queueWorker);
       // Overwrite the previous queue item with this reduced set.
       $queueItem->records = $records;
       $queue->createItem($queueItem);

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -107,8 +107,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $client->authenticate(
       $clientConfig['eloqua_rest_api_site_name'],
       $clientConfig['eloqua_rest_api_login_name'],
-      $clientConfig['eloqua_rest_api_login_password'],
-      $clientConfig['eloqua_rest_api_base_url']
+      $clientConfig['eloqua_rest_api_login_password']
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -106,10 +106,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(
       $clientConfig['eloqua_rest_api_site_name'],
-      // 'TableauSoftware',
       $clientConfig['eloqua_rest_api_login_name'],
       $clientConfig['eloqua_rest_api_login_password'],
-      'https://secure.p01.eloqua.com/API/Bulk'
+      $clientConfig['eloqua_rest_api_base_url']
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -80,22 +80,28 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
    * {@inheritdoc}
    */
   public function processItem($queueItem) {
+    $instanceId = $queueItem->instanceId;
+    $executionId = $queueItem->executionId;
+
     // The queue item may contain any number of contacts.
     // We can only send 5000 at a time. If there are more then that we need to requeue the remainder.
     // Either way, build a batch request and send it. Data items on the queue will contain an array
     // of possible records. Iterate over the records and see what we need to do.
-    $records = &$queueItem->records;
+    $records = $queueItem->records;
+
     // Splice off the first 5000 records.
     // If there are any left requeue them for the next run through.
     $chunk = array_splice($records, 0, 5000);
+
     if (count($records)) {
       // Requeue the remainder.
       /** @var QueueInterface $queue */
       $queue = $this->queueFactory->get($queueItem->queueId);
+      // Overwrite the previous queue item with this reduced set.
+      $queueItem->records = $records;
       $queue->createItem($queueItem);
     }
-    $instanceId = $queueItem->instanceId;
-    $executionId = $queueItem->executionId;
+    $this->logger->debug("Queue execution:@exid run #@chunk records, requeue #@requeue records.",["@exid" => $executionId, "@chunk" => count($chunk), "@requeue" => count($records)]);
     // $api will be either 'contacts' or 'customObjects'.
     $api = $queueItem->api;
     $fieldList = $queueItem->fieldList;

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -17,12 +17,12 @@ use Psr\Log\LoggerInterface;
  *
  * @property  logger
  * @QueueWorker(
- *  id = "eloqua_app_cloud_decision_queue_worker",
- *  title = @Translation("The Eloqua AppCloud Queue worker for decisions."),
+ *  id = "eloqua_app_cloud_content_queue_worker",
+ *  title = @Translation("The Eloqua AppCloud Queue worker for dynamic content."),
  *  cron = {"time" = 60},
  * )
  */
-class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
    * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
@@ -105,9 +105,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     // Eloqua is sometimes very slow to respond -- be wary of timeouts.
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(
-      $clientConfig['eloqua_rest_api_site_name'],
-      $clientConfig['eloqua_rest_api_login_name'],
-      $clientConfig['eloqua_rest_api_login_password']
+      $clientConfig->get('eloqua_rest_api_site_name'),
+      $clientConfig->get('eloqua_rest_api_login_name'),
+      $clientConfig->get('eloqua_rest_api_login_password')
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -25,9 +25,7 @@ use Psr\Log\LoggerInterface;
 class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
-   * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
-   *
-   * @var \Drupal\eloqua_rest_api\Factory\ClientFactory
+   * @var ClientFactory
    */
   protected $eloquaClientFactory;
 
@@ -36,10 +34,14 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
    */
   protected $queueFactory;
 
-  /** @var  ConfigFactoryInterface */
+  /**
+   * @var  ConfigFactoryInterface
+   */
   protected $configFactory;
 
-  /** @var  LoggerInterface */
+  /**
+   * @var  LoggerInterface
+   */
   protected $logger;
 
   /**

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -2,6 +2,7 @@
 
 namespace Drupal\eloqua_app_cloud\Plugin\QueueWorker;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Queue\QueueWorkerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -16,12 +17,12 @@ use Psr\Log\LoggerInterface;
  *
  * @property  logger
  * @QueueWorker(
- *  id = "eloqua_app_cloud_content_queue_worker",
- *  title = @Translation("The Eloqua AppCloud Queue worker for dynamic content."),
+ *  id = "eloqua_app_cloud_decision_queue_worker",
+ *  title = @Translation("The Eloqua AppCloud Queue worker for decisions."),
  *  cron = {"time" = 60},
  * )
  */
-class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
    * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
@@ -34,6 +35,9 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
    * @var QueueFactory
    */
   protected $queueFactory;
+
+  /** @var  ConfigFactoryInterface */
+  protected $configFactory;
 
   /** @var  LoggerInterface */
   protected $logger;
@@ -49,10 +53,11 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
    *   The plugin implementation definition.
    */
   public function __construct(
-    array $configuration, $plugin_id, $plugin_definition, ClientFactory $eloqua_client_factory, QueueFactory $queueFactory, LoggerInterface $logger) {
+    array $configuration, $plugin_id, $plugin_definition, ClientFactory $eloqua_client_factory, QueueFactory $queueFactory, ConfigFactoryInterface $configFactory, LoggerInterface $logger) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->eloquaClientFactory = $eloqua_client_factory;
     $this->queueFactory = $queueFactory;
+    $this->configFactory = $configFactory;
     $this->logger = $logger;
   }
 
@@ -66,6 +71,7 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
       $plugin_definition,
       $container->get('eloqua.client_factory'),
       $container->get('queue'),
+      $container->get('config.factory'),
       $container->get('logger.channel.eloqua_app_cloud')
     );
   }
@@ -95,7 +101,7 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
     $fieldList = $queueItem->fieldList;
     // Let's get a client so we can send our bulk API requests.
     $client = $this->eloquaClientFactory->get();
-    $clientConfig = \Drupal::config('eloqua_rest_api.settings')->get();
+    $clientConfig = $this->configFactory->get('eloqua_rest_api.settings');
     // Eloqua is sometimes very slow to respond -- be wary of timeouts.
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -72,7 +72,7 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
       $container->get('eloqua.client_factory'),
       $container->get('queue'),
       $container->get('config.factory'),
-      $container->get('logger.channel.eloqua_app_cloud')
+      $container->get('logger.channel.eloqua_app_cloud_queue')
     );
   }
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -1,0 +1,155 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\eloqua_rest_api\Factory\ClientFactory;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Psr\Log\LoggerInterface;
+
+
+/**
+ * Give it 60 seconds?
+ *
+ * @property  logger
+ * @QueueWorker(
+ *  id = "eloqua_app_cloud_content_queue_worker",
+ *  title = @Translation("The Eloqua AppCloud Queue worker for dynamic content."),
+ *  cron = {"time" = 60},
+ * )
+ */
+class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
+   *
+   * @var \Drupal\eloqua_rest_api\Factory\ClientFactory
+   */
+  protected $eloquaClientFactory;
+
+  /**
+   * @var QueueFactory
+   */
+  protected $queueFactory;
+
+  /** @var  LoggerInterface */
+  protected $logger;
+
+  /**
+   * Construct.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(
+    array $configuration, $plugin_id, $plugin_definition, ClientFactory $eloqua_client_factory, QueueFactory $queueFactory, LoggerInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->eloquaClientFactory = $eloqua_client_factory;
+    $this->queueFactory = $queueFactory;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('eloqua.client_factory'),
+      $container->get('queue'),
+      $container->get('logger.channel.eloqua_app_cloud')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($queueItem) {
+    // The queue item may contain any number of contacts.
+    // We can only send 5000 at a time. If there are more then that we need to requeue the remainder.
+    // Either way, build a batch request and send it. Data items on the queue will contain an array
+    // of possible records. Iterate over the records and see what we need to do.
+    $records = &$queueItem->records;
+    // Splice off the first 5000 records.
+    // If there are any left requeue them for the next run through.
+    $chunk = array_splice($records, 0, 5000);
+    if (count($records)) {
+      // Requeue the remainder.
+      /** @var QueueInterface $queue */
+      $queue = $this->queueFactory->get($queueItem->queueId);
+      $queue->createItem($queueItem);
+    }
+    $instanceId = $queueItem->instanceId;
+    $executionId = $queueItem->executionId;
+    // $api will be either 'contacts' or 'customObjects'.
+    $api = $queueItem->api;
+    $fieldList = $queueItem->fieldList;
+    // Let's get a client so we can send our bulk API requests.
+    $client = $this->eloquaClientFactory->get();
+    $clientConfig = \Drupal::config('eloqua_rest_api.settings')->get();
+    // Eloqua is sometimes very slow to respond -- be wary of timeouts.
+    $client->getHttpClient()->setOption('timeout', 90000);
+    $client->authenticate(
+      $clientConfig['eloqua_rest_api_site_name'],
+      // 'TableauSoftware',
+      $clientConfig['eloqua_rest_api_login_name'],
+      $clientConfig['eloqua_rest_api_login_password'],
+      'https://secure.p01.eloqua.com/API/Bulk'
+    );
+
+
+    // @TODO how to really handle custom objects.
+    // If $cdo_id is set, push the Id to bulk process.
+    if (!empty($cdoId)) {
+      $bulkApi = $client->api($api)->bulk($cdoId);
+    }
+    else {
+      $bulkApi = $client->api($api)->bulk();
+    }
+
+    // Sets connector to 'import' mode.
+    $bulkApi->imports();
+
+    $mapping = [
+      'name' => 'Content results import',
+      'identifierFieldName' => 'EmailAddress',
+      'updateRule' => "always",
+      'fields' => $fieldList,
+    ];
+
+    // Now run through the chunk we have and create the data to return.
+    $data = [];
+    foreach ($chunk as $record) {
+      $item = new \stdClass();
+      $item->EmailAddress = $record->EmailAddress;
+      $data[] = $item;
+    }
+
+    $destination = '{{ContentInstance(' . $this->formatGuid($instanceId) . ').Execution[' . $executionId . ']}}';
+    // Now send the list of completed contents.
+    if (count($data)) {
+      $mapping['syncContents'] = [
+        'destination' => $destination,
+        'content' => 'setStatus',
+        'status' => 'complete',
+      ];
+      // Sends setup/mapping array to Eloqua.
+      $bulkApi->map($mapping);
+      $this->tryBulkApiUpload($bulkApi, $data, $this->logger);
+      $this->tryBulkApiSync($bulkApi, $this->logger);
+      $status = $this->getBulkApiStatus($bulkApi);
+      $msg = "Status Returned for Content: " . $status;
+      $this->logger->info($msg);
+    }
+  }
+
+}

--- a/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudContentQueueWorker.php
@@ -97,8 +97,7 @@ class EloquaAppCloudContentQueueWorker extends EloquaAppCloudQueueWorkerBase imp
 
     if (count($records)) {
       // Requeue the remainder.
-      /** @var QueueInterface $queue */
-      $queue = $this->queueFactory->get($queueItem->queueId);
+      $queue = $this->queueFactory->get($queueItem->queueWorker);
       // Overwrite the previous queue item with this reduced set.
       $queueItem->records = $records;
       $queue->createItem($queueItem);

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -80,22 +80,29 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
    * {@inheritdoc}
    */
   public function processItem($queueItem) {
+    $instanceId = $queueItem->instanceId;
+    $executionId = $queueItem->executionId;
+
     // The queue item may contain any number of contacts.
     // We can only send 5000 at a time. If there are more then that we need to requeue the remainder.
     // Either way, build a batch request and send it. Data items on the queue will contain an array
     // of possible records. Iterate over the records and see what we need to do.
-    $records = &$queueItem->records;
+    $records = $queueItem->records;
+
     // Splice off the first 5000 records.
     // If there are any left requeue them for the next run through.
     $chunk = array_splice($records, 0, 5000);
+
     if (count($records)) {
       // Requeue the remainder.
       /** @var QueueInterface $queue */
       $queue = $this->queueFactory->get($queueItem->queueId);
+      // Overwrite the previous queue item with this reduced set.
+      $queueItem->records = $records;
       $queue->createItem($queueItem);
     }
-    $instanceId = $queueItem->instanceId;
-    $executionId = $queueItem->executionId;
+    $this->logger->debug("Queue execution:@exid run #@chunk records, requeue #@requeue records.",["@exid" => $executionId, "@chunk" => count($chunk), "@requeue" => count($records)]);
+
     // $api will be either 'contacts' or 'customObjects'.
     $api = $queueItem->api;
     $fieldList = $queueItem->fieldList;

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -107,8 +107,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $client->authenticate(
       $clientConfig['eloqua_rest_api_site_name'],
       $clientConfig['eloqua_rest_api_login_name'],
-      $clientConfig['eloqua_rest_api_login_password'],
-      $clientConfig['eloqua_rest_api_base_url']
+      $clientConfig['eloqua_rest_api_login_password']
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -72,7 +72,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       $container->get('eloqua.client_factory'),
       $container->get('queue'),
       $container->get('config.factory'),
-      $container->get('logger.channel.eloqua_app_cloud')
+      $container->get('logger.channel.eloqua_app_cloud_queue')
     );
   }
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -151,11 +151,11 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       // Sends setup/mapping array to Eloqua.
       $bulkApi->map($mapping);
       $this->tryBulkApiUpload($bulkApi, $yes, $this->logger);
-      $this->logger->info(print_r("Upload request was " + $client->getHttpClient()->getLastRequest(), TRUE));
+      $this->logger->info("Upload request was " + print_r($client->getHttpClient()->getLastRequest(), TRUE));
       $this->tryBulkApiSync($bulkApi, $this->logger);
-      $this->logger->info(print_r("Sync request was " + $client->getHttpClient()->getLastRequest(), TRUE));
+      $this->logger->info("Sync request was " + print_r($client->getHttpClient()->getLastRequest(), TRUE));
       $status = $this->getBulkApiStatus($bulkApi);
-      $msg = "Status Returned for YESes: " . $status;
+      $msg = "Status Returned for YES: " . $status;
       $this->logger->info($msg);
     }
     if (count($no)) {
@@ -170,7 +170,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       $this->tryBulkApiUpload($bulkApi, $no, $this->logger);
       $this->tryBulkApiSync($bulkApi, $this->logger);
       $status = $this->getBulkApiStatus($bulkApi);
-      $msg = "Status Returned for NOes: " . $status;
+      $msg = "Status Returned for NO: " . $status;
       $this->logger->info($msg);
     }
   }

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -105,9 +105,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     // Eloqua is sometimes very slow to respond -- be wary of timeouts.
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(
-      $clientConfig['eloqua_rest_api_site_name'],
-      $clientConfig['eloqua_rest_api_login_name'],
-      $clientConfig['eloqua_rest_api_login_password']
+      $clientConfig->get('eloqua_rest_api_site_name'),
+      $clientConfig->get('eloqua_rest_api_login_name'),
+      $clientConfig->get('eloqua_rest_api_login_password')
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -106,10 +106,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $client->getHttpClient()->setOption('timeout', 90000);
     $client->authenticate(
       $clientConfig['eloqua_rest_api_site_name'],
-      // 'TableauSoftware',
       $clientConfig['eloqua_rest_api_login_name'],
       $clientConfig['eloqua_rest_api_login_password'],
-      'https://secure.p01.eloqua.com/API/Bulk'
+      $clientConfig['eloqua_rest_api_base_url']
     );
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -151,9 +151,8 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       // Sends setup/mapping array to Eloqua.
       $bulkApi->map($mapping);
       $this->tryBulkApiUpload($bulkApi, $yes, $this->logger);
-      $this->logger->info("Upload request was " + print_r($client->getHttpClient()->getLastRequest(), TRUE));
+      $this->logger->info(print_r($mapping, TRUE));
       $this->tryBulkApiSync($bulkApi, $this->logger);
-      $this->logger->info("Sync request was " + print_r($client->getHttpClient()->getLastRequest(), TRUE));
       $status = $this->getBulkApiStatus($bulkApi);
       $msg = "Status Returned for YES: " . $status;
       $this->logger->info($msg);
@@ -167,6 +166,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       ];
       // Sends setup/mapping array to Eloqua.
       $bulkApi->map($mapping);
+      $this->logger->info(print_r($mapping, TRUE));
       $this->tryBulkApiUpload($bulkApi, $no, $this->logger);
       $this->tryBulkApiSync($bulkApi, $this->logger);
       $status = $this->getBulkApiStatus($bulkApi);

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -151,7 +151,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       // Sends setup/mapping array to Eloqua.
       $bulkApi->map($mapping);
       $this->tryBulkApiUpload($bulkApi, $yes, $this->logger);
+      $this->logger->info(print_r("Upload request was " + $client->getHttpClient()->getLastRequest(), TUE));
       $this->tryBulkApiSync($bulkApi, $this->logger);
+      $this->logger->info(print_r("Upload request was " + $client->getHttpClient()->getLastRequest(), TUE));
       $status = $this->getBulkApiStatus($bulkApi);
       $msg = "Status Returned for YESes: " . $status;
       $this->logger->info($msg);

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -130,7 +130,6 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
     $yes = [];
     $no = [];
     foreach ($chunk as $record) {
-      $this->logger->info(print_r($record, TRUE));
       $item = new \stdClass();
       $item->EmailAddress = $record->EmailAddress;
       if ($record->result) {

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -25,9 +25,7 @@ use Psr\Log\LoggerInterface;
 class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
   /**
-   * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
-   *
-   * @var \Drupal\eloqua_rest_api\Factory\ClientFactory
+   * @var ClientFactory
    */
   protected $eloquaClientFactory;
 
@@ -36,10 +34,14 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
    */
   protected $queueFactory;
 
-  /** @var  ConfigFactoryInterface */
+  /**
+   * @var  ConfigFactoryInterface
+   */
   protected $configFactory;
 
-  /** @var  LoggerInterface */
+  /**
+   * @var  LoggerInterface
+   */
   protected $logger;
 
   /**

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -1,0 +1,176 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Drupal\eloqua_rest_api\Factory\ClientFactory;
+use Drupal\Core\Queue\QueueFactory;
+use Drupal\Core\Queue\QueueInterface;
+use Psr\Log\LoggerInterface;
+
+
+/**
+ * Give it 60 seconds?
+ *
+ * @property  logger
+ * @QueueWorker(
+ *  id = "eloqua_app_cloud_decision_queue_worker",
+ *  title = @Translation("The Eloqua AppCloud Queue worker for decisions."),
+ *  cron = {"time" = 60},
+ * )
+ */
+class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Drupal\eloqua_rest_api\Factory\ClientFactory definition.
+   *
+   * @var \Drupal\eloqua_rest_api\Factory\ClientFactory
+   */
+  protected $eloquaClientFactory;
+
+  /**
+   * @var QueueFactory
+   */
+  protected $queueFactory;
+
+  /** @var  LoggerInterface */
+  protected $logger;
+
+  /**
+   * Construct.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param string $plugin_definition
+   *   The plugin implementation definition.
+   */
+  public function __construct(
+    array $configuration, $plugin_id, $plugin_definition, ClientFactory $eloqua_client_factory, QueueFactory $queueFactory, LoggerInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->eloquaClientFactory = $eloqua_client_factory;
+    $this->queueFactory = $queueFactory;
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('eloqua.client_factory'),
+      $container->get('queue'),
+      $container->get('logger.channel.eloqua_app_cloud')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($queueItem) {
+    // The queue item may contain any number of contacts.
+    // We can only send 5000 at a time. If there are more then that we need to requeue the remainder.
+    // Either way, build a batch request and send it. Data items on the queue will contain an array
+    // of possible records. Iterate over the records and see what we need to do.
+    $records = &$queueItem->records;
+    // Splice off the first 5000 records.
+    // If there are any left requeue them for the next run through.
+    $chunk = array_splice($records, 0, 5000);
+    if (count($records)) {
+      // Requeue the remainder.
+      /** @var QueueInterface $queue */
+      $queue = $this->queueFactory->get($queueItem->queueId);
+      $queue->createItem($queueItem);
+    }
+    $instanceId = $queueItem->instanceId;
+    $executionId = $queueItem->executionId;
+    // $api will be either 'contacts' or 'customObjects'.
+    $api = $queueItem->api;
+    $fieldList = $queueItem->fieldList;
+    // Let's get a client so we can send our bulk API requests.
+    $client = $this->eloquaClientFactory->get();
+    $clientConfig = \Drupal::config('eloqua_rest_api.settings')->get();
+    // Eloqua is sometimes very slow to respond -- be wary of timeouts.
+    $client->getHttpClient()->setOption('timeout', 90000);
+    $client->authenticate(
+      $clientConfig['eloqua_rest_api_site_name'],
+      // 'TableauSoftware',
+      $clientConfig['eloqua_rest_api_login_name'],
+      $clientConfig['eloqua_rest_api_login_password'],
+      'https://secure.p01.eloqua.com/API/Bulk'
+    );
+
+
+    // @TODO how to really handle custom objects.
+    // If $cdo_id is set, push the Id to bulk process.
+    if (!empty($cdoId)) {
+      $bulkApi = $client->api($api)->bulk($cdoId);
+    }
+    else {
+      $bulkApi = $client->api($api)->bulk();
+    }
+
+    // Sets connector to 'import' mode.
+    $bulkApi->imports();
+
+    $mapping = [
+      'name' => 'Decision results import',
+      'identifierFieldName' => 'EmailAddress',
+      'updateRule' => "always",
+      'fields' => $fieldList,
+    ];
+
+    // Now run through the chunk we have and split into yeses and noes.
+    $yes = [];
+    $no = [];
+    foreach ($chunk as $record) {
+      $item = new \stdClass();
+      $item->EmailAddress = $record->EmailAddress;
+      if ($record->result) {
+        $yes[] = $item;
+      }
+      else {
+        $no[] = $item;
+      }
+    }
+
+    $destination = '{{DecisionInstance(' . $this->formatGuid($instanceId) . ').Execution[' . $executionId . ']}}';
+    // Now send the YESes.
+    if (count($yes)) {
+      $mapping['syncActions'] = [
+        'destination' => $destination,
+        'action' => 'setStatus',
+        'status' => 'yes',
+      ];
+      // Sends setup/mapping array to Eloqua.
+      $bulkApi->map($mapping);
+      $this->tryBulkApiUpload($bulkApi, $yes, $this->logger);
+      $this->tryBulkApiSync($bulkApi, $this->logger);
+      $status = $this->getBulkApiStatus($bulkApi);
+      $msg = "Status Returned for YESes: " . $status;
+      $this->logger->info($msg);
+    }
+    if (count($no)) {
+      // Repeat with the NOes.
+      $mapping['syncActions'] = [
+        'destination' => $destination,
+        'action' => 'setStatus',
+        'status' => 'no',
+      ];
+      // Sends setup/mapping array to Eloqua.
+      $bulkApi->map($mapping);
+      $this->tryBulkApiUpload($bulkApi, $no, $this->logger);
+      $this->tryBulkApiSync($bulkApi, $this->logger);
+      $status = $this->getBulkApiStatus($bulkApi);
+      $msg = "Status Returned for NOes: " . $status;
+      $this->logger->info($msg);
+    }
+  }
+
+}

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -151,9 +151,9 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
       // Sends setup/mapping array to Eloqua.
       $bulkApi->map($mapping);
       $this->tryBulkApiUpload($bulkApi, $yes, $this->logger);
-      $this->logger->info(print_r("Upload request was " + $client->getHttpClient()->getLastRequest(), TUE));
+      $this->logger->info(print_r("Upload request was " + $client->getHttpClient()->getLastRequest(), TRUE));
       $this->tryBulkApiSync($bulkApi, $this->logger);
-      $this->logger->info(print_r("Upload request was " + $client->getHttpClient()->getLastRequest(), TUE));
+      $this->logger->info(print_r("Sync request was " + $client->getHttpClient()->getLastRequest(), TRUE));
       $status = $this->getBulkApiStatus($bulkApi);
       $msg = "Status Returned for YESes: " . $status;
       $this->logger->info($msg);

--- a/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudDecisionQueueWorker.php
@@ -97,8 +97,7 @@ class EloquaAppCloudDecisionQueueWorker extends EloquaAppCloudQueueWorkerBase im
 
     if (count($records)) {
       // Requeue the remainder.
-      /** @var QueueInterface $queue */
-      $queue = $this->queueFactory->get($queueItem->queueId);
+      $queue = $this->queueFactory->get($queueItem->queueWorker);
       // Overwrite the previous queue item with this reduced set.
       $queueItem->records = $records;
       $queue->createItem($queueItem);

--- a/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
@@ -6,6 +6,7 @@ use Drupal\Core\Queue\QueueWorkerInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Queue\QueueWorkerBase;
 use Drupal\eloqua_app_cloud\Exception\EloquaAppCloudQueueException;
+use Exception;
 use Psr\Log\LoggerInterface;
 
 
@@ -31,6 +32,8 @@ abstract class EloquaAppCloudQueueWorkerBase extends QueueWorkerBase implements 
    *
    * @param {Logger} $logger
    *    Logger object for logging routine info / errors.
+   *
+   * @throws \Drupal\eloqua_app_cloud\Exception\EloquaAppCloudQueueException
    */
   protected function tryBulkApiUpload($bulkApi, $contactsToBeStaged, LoggerInterface $logger) {
     $retries = 1;
@@ -79,6 +82,8 @@ abstract class EloquaAppCloudQueueWorkerBase extends QueueWorkerBase implements 
    *
    * @return {String} $uri
    *    The Sync endpoint URI used to access Eloqua Sync data.
+   *
+   * @throws \Drupal\eloqua_app_cloud\Exception\EloquaAppCloudQueueException
    */
   protected function tryBulkApiSync($bulkApi, LoggerInterface $logger) {
     $retries = 1;

--- a/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
@@ -8,15 +8,6 @@ use Drupal\Core\Queue\QueueWorkerBase;
 use Psr\Log\LoggerInterface;
 
 
-/**
- * Give it 60 seconds?
- *
- * @QueueWorker(
- *  id = "eloqua_app_cloud_queue_worker_base",
- *  title = @Translation("The Eloqua AppCloud Queue worker Base."),
- *  cron = {"time" = 60},
- * )
- */
 abstract class EloquaAppCloudQueueWorkerBase extends QueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
 
 

--- a/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
@@ -1,0 +1,186 @@
+<?php
+
+namespace Drupal\eloqua_app_cloud\Plugin\QueueWorker;
+
+use Drupal\Core\Queue\QueueWorkerInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
+use Drupal\Core\Queue\QueueWorkerBase;
+use Psr\Log\LoggerInterface;
+
+
+/**
+ * Give it 60 seconds?
+ *
+ * @QueueWorker(
+ *  id = "eloqua_app_cloud_queue_worker_base",
+ *  title = @Translation("The Eloqua AppCloud Queue worker Base."),
+ *  cron = {"time" = 60},
+ * )
+ */
+abstract class EloquaAppCloudQueueWorkerBase extends QueueWorkerBase implements QueueWorkerInterface, ContainerFactoryPluginInterface {
+
+
+  /**
+   * {@inheritdoc}
+   */
+  public function processItem($queueItem) {
+
+  }
+
+  /**
+   * Wraps try/catch and retry attempts around Elomentary's $bulkApi->upload()
+   * function.
+   *
+   * @param {Object} $bulkApi
+   *    Elomentary bulkApi object reference.
+   *
+   * @param {Array} $contactsToBeStaged
+   *    Reference to the $contacts to be staged array.
+   *
+   * @param {Logger} $logger
+   *    Logger object for logging routine info / errors.
+   */
+  protected function tryBulkApiUpload($bulkApi, $contactsToBeStaged, LoggerInterface $logger) {
+    $retries = 1;
+    $maxRetries = 10;
+
+    try {
+      // Upload content to Eloqua staging area.
+      $bulkApi->upload($contactsToBeStaged);
+    } catch (Exception $e) {
+
+      $msg = "Upload Failed! Caught Exception: " . $e->getMessage();
+      $logger->error($msg);
+
+      // Retry for $maxRetries attempts.
+      for ($retries; $retries <= $maxRetries; $retries++) {
+        try {
+
+          // Upload content to Eloqua staging area.
+          $bulkApi->upload($contactsToBeStaged);
+          // Uploaded contacts successfully.
+          return;
+        } catch (Exception $e) {
+          $msg = "Reupload attempt #$retries Failed! Caught Exception: " . $e->getMessage();
+          $logger->error($msg);
+        }
+      }
+
+      $msg = "Upload failed after multiple retries.";
+      $msg .= print_r($bulkApi->log(), TRUE);
+      $msg .= "Caught Exception: " . $e->getMessage();
+      $logger->error($msg);
+    }
+  }
+
+  /**
+   * Wraps try/catch and retry attempts around Elomentary's $bulkApi->sync()
+   * function.
+   *
+   * @param {Object} $bulkApi
+   *    Elomentary bulkApi object reference.
+   *
+   * @param {Logger} $logger
+   *    Logger object for logging routine info / errors.
+   *
+   * @return {String} $uri
+   *    The Sync endpoint URI used to access Eloqua Sync data.
+   */
+  protected function tryBulkApiSync($bulkApi, LoggerInterface $logger) {
+    $retries = 1;
+    // In case of API failures, up to 5 retry attempts.
+    $maxRetries = 5;
+
+    try {
+      // Sync uploaded contacts in staging with Eloqua.
+      $bulkApi->sync();
+      $currentStatus = $this->getBulkApiStatus($bulkApi);
+
+      // $bulkApi->status() when passed true,
+      // will block until the upload succeeds or fails.
+      if ($currentStatus === 'success' || $currentStatus === 'warning') {
+        $msg = "Status Returned: " . $currentStatus;
+        $logger->info($msg);
+        $msg = "Sync completed successfully!";
+        $logger->info($msg);
+      }
+
+      $syncResponse = $bulkApi->getResponse('sync', NULL);
+
+      $msg = "syncResponse is: " . print_r($syncResponse, TRUE) . "\n";
+      $logger->info($msg);
+      $uri = trim($syncResponse['uri'], '/');
+      $msg = "Import URI is: $uri\n";
+      $logger->info($msg);
+      return $uri;
+
+    } catch (Exception $e) {
+      $msg = "Sync Failed! Caught Exception: " . $e->getMessage();
+      $logger->error($msg);
+
+      for ($retries; $retries <= $maxRetries; $retries++) {
+        try {
+          // Attempt to sync.
+          $bulkApi->sync();
+
+          // Poll for sync status response.
+          $currentStatus = $this->getBulkApiStatus($bulkApi);
+
+          // A successful status response is either 'success' or 'warning'.
+          if ($currentStatus === 'success' || $currentStatus === 'warning') {
+            $msg = "Status Returned: " . $currentStatus;
+            $logger->info($msg);
+            $msg = "Sync completed successfully!";
+            $logger->info($msg);
+            $syncResponse = $bulkApi->getResponse('sync', NULL);
+            $uri = trim($syncResponse['uri'], '/');
+            $logger->info($msg);
+            return $uri;
+            return $uri;
+          }
+
+        } catch (Exception $e) {
+          $msg = "Sync retry attempt #$retries returned status: $currentStatus.";
+          $msg .= "Sync Failed! Caught Exception: " . $e->getMessage();
+
+          $logger->error($msg);
+
+          // Retrieving processing log of last bulk API transfer.
+          $msg = $bulkApi->log();
+          $logger->error($msg);
+        }
+      }
+
+    }
+  }
+
+  /**
+   * Retrieve the bulkApi's sync() status.
+   *
+   *  $bulkApi->status(true) blocks execution until a success or failure
+   *    status is returned by Eloqua
+   *
+   * @param {Object} $bulkApi
+   *   The bulkApi client object.
+   *
+   * @return {String} status
+   *   Sync status reponse from Eloqua after calling $bulkApi->sync()
+   */
+  protected function getBulkApiStatus($bulkApi) {
+    // Poll for bulkApi status response (blocking).
+    $statusArr = $bulkApi->status(TRUE);
+    return $statusArr['status'];
+  }
+
+  /**
+   * Eloqua sends us the instance ID as a guid with dashes but does not want
+   * dashes back.
+   *
+   * @param $guid
+   */
+  protected function formatGuid($guid) {
+    $guid = str_replace('-', '', $guid);
+    return $guid;
+  }
+
+}

--- a/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
+++ b/src/Plugin/QueueWorker/EloquaAppCloudQueueWorkerBase.php
@@ -130,7 +130,6 @@ abstract class EloquaAppCloudQueueWorkerBase extends QueueWorkerBase implements 
             $uri = trim($syncResponse['uri'], '/');
             $logger->info($msg);
             return $uri;
-            return $uri;
           }
 
         } catch (Exception $e) {

--- a/templates/eloqua_app_cloud_update.html.twig
+++ b/templates/eloqua_app_cloud_update.html.twig
@@ -1,0 +1,24 @@
+{#
+/**
+ * @file eloqua_app_cloud_update.html.twig
+ * Default theme implementation to present Eloqua AppCloud updates calls.
+ *
+ * This template is used when viewing Eloqua AppCloud configure popups.
+ *
+ *
+ * Available variables:
+ * - content: A list of content items. Use 'content' to print all content, or
+ * - attributes: HTML attributes for the container element.
+ *
+ * @see template_preprocess_eloqua_app_cloud_service()
+ *
+ * @ingroup themeable
+ */
+#}
+<div>
+  {% if content %}
+      {% for plugin in content %}
+        <div>{{ plugin }}</div>
+      {% endfor %}
+  {% endif %}
+</div>

--- a/templates/eloqua_app_cloud_update_dialog.html.twig
+++ b/templates/eloqua_app_cloud_update_dialog.html.twig
@@ -1,9 +1,10 @@
 {#
 /**
- * @file eloqua_app_cloud_update.html.twig
+ * @file eloqua_app_cloud_update_dialog.html.twig
  * Default theme implementation to present Eloqua AppCloud updates calls.
  *
- * This template is used when viewing Eloqua AppCloud configure popups.
+ * This template is used when viewing Eloqua AppCloud configure popups
+ * in the Eloqua canvas UI.
  *
  *
  * Available variables:


### PR DESCRIPTION
Creates a decision plugin class, and a queue worker to help it.
Also introduces a "breaking" change in the namespaces for existing plugins from "eloqua_app_cloud_firehose_responder" to "eloqua_app_cloud.firehose_responder".
This will require any existing service entities to be edited and saved so the plugins are rediscovered.

I would love some feedback on the queue worker class(es) since I am unsure of the choices I made there. In particular, the injection of the logger, and the lack of an interface.